### PR TITLE
Fixed Bug when detencting NVIDIA GPUs

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -27,7 +27,7 @@ checkcommand()
 
 # This will print three lines. The first one is the the total vRAM available,
 # the second one is the used vRAM and the third on is the GPU usage in %.
-if checkcommand nvidia-smi; then
+if nvidia-smi --list-gpus > /dev/null 2>&1  ; then
 	nvidia-smi -i 0 --query-gpu=memory.total,memory.used,utilization.gpu --format=csv,noheader,nounits | while IFS=', ' read -r a b c; do echo "$a"; echo "$b"; echo "$c"; done
 
 elif lsmod | grep amdgpu > /dev/null; then


### PR DESCRIPTION
**Fix GPU detection when switching from NVIDIA to AMD**

**Bug Description**
When a user switches from an NVIDIA GPU to an AMD GPU, the GPU stats in the top bar stop working completely. This occurs because the current implementation only checks for the existence of the nvidia-smi command but not its functionality.


**Current Behavior**
Extension checks if nvidia-smi command exists using checkcommand
If the command exists (even if NVIDIA GPU is no longer present), it attempts to use NVIDIA monitoring
This fails silently and prevents fallback to AMD GPU monitoring
Results in no GPU stats being displayed

**Solution**
Modified the GPU detection logic to verify NVIDIA GPU is actually present and functional:
bash

### What I tested

- [V] Verified no regressions to existing functionality.
- [V] Tested on the following Gnome Shell versions: 47.2


