### PR TITLE
add fallback logic for locale

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -2447,6 +2447,14 @@ export default class SystemMonitorExtension extends Extension {
             this._Locale = this._Locale.split('_')[0];
         }
 
+        // fallback to en for unsupported locale
+        try {
+            new Date().toLocaleString(this._Locale);
+        } catch (e) {
+            sm_log('fallback to EN: ' + e.message, 'warn')
+            this._Locale = 'en'
+        }
+
         this._IconSize = Math.round(PANEL_ICON_SIZE * 4 / 5);
 
         this._Schema = this.getSettings();


### PR DESCRIPTION
Unsupported locale can fallback to English, not just fails to load the extension.

### What I tested

can properly work on ubuntu 24.04 with GS v46 and LANG=C.UTF-8

### Screenshots

![image](https://github.com/user-attachments/assets/bf85d307-9025-42bf-8bfe-64dd67810eec)
