### PR TITLE
ci: Use official AUR repo for arch build test clone

### DIFF
--- a/actions/build-test-arch/entry.sh
+++ b/actions/build-test-arch/entry.sh
@@ -11,7 +11,7 @@ mkdir -p /home/builder/build
 cd /home/builder/build
 
 # Clone the AUR build files
-git clone https://github.com/mgalgs/gnome-shell-extension-system-monitor-next-git.git
+git clone https://aur.archlinux.org/gnome-shell-extension-system-monitor-next-git.git
 cd gnome-shell-extension-system-monitor-next-git
 makepkg --install --noconfirm
 


### PR DESCRIPTION
AUR has been updated so we can point at that instead of my PKGBUILD fork. Opening this PR to ensure tests still pass in CI (already verified local).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/127)
<!-- Reviewable:end -->
