### PR TITLE
Easier multi-device configurations and related improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,51 @@
 # Changelog
 
-Notable changes, newest first. Entries are written for someone who noticed
-something different on their panel and came here to find out whether it is a bug.
+Notable changes, newest first.
 
 ## Unreleased
 
-### Your disk read and write figures will look different — and the new ones are right
+### Changed measurements
 
-Two separate errors had been partly cancelling each other out. The panel used the
-wrong conversion from disk sectors to MiB, which made every figure four times too
-small. And *All disks* added up the same read or write once for every layer of
-your storage — once for the partition, again for LVM or disk encryption if you use
-them, and again for the disk itself.
+- Disk read/write used the wrong sector-size conversion; every disk figure was 4× too small.
+- "All disks" counted the same I/O once per storage layer (disk, partition, LVM, LUKS); it now counts physical disks only.
+- Combined effect on the disk total: ~4× larger on a bare disk, ~2× larger on a partitioned one, about the same on encrypted LVM. The new figures match `iostat`.
+- "All interfaces" counted VPN, bridge, and Docker traffic twice; it now counts physical interfaces only, so the total is lower and correct. ([#81], [#101])
+- A monitor whose device cannot be read now shows `--` instead of a stale value, a zero, or a constant 99%.
+- A Thermal or Fan monitor that was always blank now shows `--`; it has no sensor selected.
 
-Because they pulled in opposite directions, how far your number moves depends on
-your setup: roughly **4× larger** with a single unpartitioned disk, **2× larger**
-with an ordinary partitioned one, and **about the same** if you run LVM on an
-encrypted partition.
+### Added
 
-Whichever it is, the figure now matches what `iostat` reports for the same moment.
-If it does not, that is a bug worth filing.
+- One monitor can cover multiple devices, e.g. all CPU cores in a single entry. ([#150])
+- Device selection has its own dialog; the monitor row shows a summary like "5 of 5 selected".
+- Each device has its own Show Text switch, plus a bulk control for the whole list.
+- A multi-device monitor is one grouped entry in the popup menu instead of one row per device.
+- A new multi-device monitor picks a graph width that fits the panel.
+- The disk picker lists every block device the panel can read, including LVM, LUKS, and zram devices.
+- The network picker lists every interface, including tunnels NetworkManager does not manage such as `wg-quick`.
+- A widget that cannot find its device logs the reason and the available devices to the journal.
+- Devices have human names: "Core 1" instead of "0".
+- Memory and Swap no longer show a one-item device picker.
+- NetworkManager is no longer required.
 
-Separately, the device list in preferences now offers every disk on your machine —
-including LVM volumes, encrypted devices and zram — instead of the four families
-of names it used to recognise.
+### Fixed
 
-### A monitor with no reading now shows `--` instead of a number it does not have
+- Preferences failed to open if a monitor config was missing `display` or `show-menu`.
+- A monitor with many devices pushed "System Monitor…" and "Preferences…" off the bottom of the popup menu.
+- A new multi-device monitor was created with its popup menu entry switched off.
+- The popup menu went blank after a settings change until the next refresh.
+- Network and disk totals showed a large negative rate when a device disappeared (VPN drop, USB unplug, LUKS/LVM close).
+- Graphs on the same refresh interval drifted out of step; they now update together.
+- The GPU picker showed two entries for the same card on hybrid-graphics machines.
+- Only the first AMD GPU was detected.
+- A disk monitor could match another device whose name contained its own.
+- Two monitors with the same uuid left the panel half-built.
+- A malformed `/proc/diskstats` row turned the disk total into NaN.
+- Monitors that an old migration split one-per-core are merged back into a single entry.
 
-A disk that was unplugged, a CPU core this machine does not have, a sensor that is
-not on this machine, an interface that was renamed — each of these used to show a
-stale figure, a zero, or in one case a large negative rate, all of which looked
-like measurements. They now show `--`, and the journal names what the source did
-contain.
+### Performance
 
-If a Thermal or Fan monitor on your panel has always been blank, it will now read
-`--`. It never had a sensor selected; pick one in preferences, or remove the
-monitor.
-
-### Network totals no longer count tunnelled and bridged traffic twice
-
-If you use a VPN, a bridge, or Docker, the *All interfaces* figure was roughly
-double the real throughput: the same bytes were counted once on the virtual
-interface and again on the hardware carrying them. It now counts only the
-interfaces where traffic actually enters or leaves the machine, so the number will
-be **lower, and correct**. ([#81], [#101])
-
-To watch a tunnel or bridge specifically, add a monitor for that interface in
-preferences — which now also works for tunnels NetworkManager does not manage,
-such as `wg-quick`.
-
-[#81]: https://github.com/mgalgs/gnome-shell-system-monitor-next-applet/issues/81
-[#101]: https://github.com/mgalgs/gnome-shell-system-monitor-next-applet/issues/101
+- Each data source (`/proc/stat`, `/proc/diskstats`, `/proc/net/dev`, `sensors`, the GPU script, Prometheus) is read once per tick and shared by all widgets.
+- Widgets on the same refresh interval share one timer.
+- GPU monitoring runs `nvidia-smi` once per tick instead of twice per GPU.
+- Prometheus metrics from one server share one scrape per tick instead of one each.
+- Sensor readings are no longer served from a cache up to a second stale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+Notable changes, newest first. Entries are written for someone who noticed
+something different on their panel and came here to find out whether it is a bug.
+
+## Unreleased
+
+### Your disk read and write figures will look different — and the new ones are right
+
+Two separate errors had been partly cancelling each other out. The panel used the
+wrong conversion from disk sectors to MiB, which made every figure four times too
+small. And *All disks* added up the same read or write once for every layer of
+your storage — once for the partition, again for LVM or disk encryption if you use
+them, and again for the disk itself.
+
+Because they pulled in opposite directions, how far your number moves depends on
+your setup: roughly **4× larger** with a single unpartitioned disk, **2× larger**
+with an ordinary partitioned one, and **about the same** if you run LVM on an
+encrypted partition.
+
+Whichever it is, the figure now matches what `iostat` reports for the same moment.
+If it does not, that is a bug worth filing.
+
+Separately, the device list in preferences now offers every disk on your machine —
+including LVM volumes, encrypted devices and zram — instead of the four families
+of names it used to recognise.
+
+### A monitor with no reading now shows `--` instead of a number it does not have
+
+A disk that was unplugged, a CPU core this machine does not have, a sensor that is
+not on this machine, an interface that was renamed — each of these used to show a
+stale figure, a zero, or in one case a large negative rate, all of which looked
+like measurements. They now show `--`, and the journal names what the source did
+contain.
+
+If a Thermal or Fan monitor on your panel has always been blank, it will now read
+`--`. It never had a sensor selected; pick one in preferences, or remove the
+monitor.
+
+### Network totals no longer count tunnelled and bridged traffic twice
+
+If you use a VPN, a bridge, or Docker, the *All interfaces* figure was roughly
+double the real throughput: the same bytes were counted once on the virtual
+interface and again on the hardware carrying them. It now counts only the
+interfaces where traffic actually enters or leaves the machine, so the number will
+be **lower, and correct**. ([#81], [#101])
+
+To watch a tunnel or bridge specifically, add a monitor for that interface in
+preferences — which now also works for tunnels NetworkManager does not manage,
+such as `wg-quick`.
+
+[#81]: https://github.com/mgalgs/gnome-shell-system-monitor-next-applet/issues/81
+[#101]: https://github.com/mgalgs/gnome-shell-system-monitor-next-applet/issues/101

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,9 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
   - `smSamplers` — the per-extension registry, `extension._Samplers`
 - **`common.js`**: Shared utilities (`parse_bytearray()`, `check_sensors()`)
 - **`utils.js`**: Logging (`sm_log()`)
-- **`migration.js`**: Settings schema migration (v0 → v1 → v2)
+- **`migration.js`**: Settings schema migration (v0 → v1 → v2 → v3)
   - v1→v2: converts per-widget GSettings keys into JSON `monitors` array
+  - v2→v3: converts each monitor's single `device` into a `devices` set, coalescing adjacent monitors that differ only by device
 
 ### Settings and Schemas
 
@@ -286,6 +287,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for full details. Key rules for AI agents
 
 - **Network disk usage monitoring is disabled by default** (`ENABLE_NETWORK_DISK_USAGE = false` in `extension.js:53`) because stale network shares can freeze the shell
 - The extension uses ES6 modules (import/export) introduced in GNOME Shell 45
-- Settings migration happens automatically on extension load via `migrateSettings()` (current schema version: 2)
+- Settings migration happens automatically on extension load via `migrateSettings()` (current schema version: 3)
 - The extension UUID is hardcoded throughout and must match the directory name
 - Graph width, refresh times, and colors are all user-configurable per metric type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
   - `onSettingsChanged(newConfig)` for live config updates without recreating widgets
   - `collect()` API — widgets return `{metricKey: value}`, framework auto-updates display
   - `Chart` — stacked area graph rendering (Cairo)
+  - `build_menu_info()` — the popup menu's table, **one entry per monitor**: a monitor with one visible device is a row titled `item_name`, one with several writes its type once and wraps its devices beneath it. A widget's `menu_items` belong to the widget; the table borrows them and returns them before each rebuild
   - `TipBox`/`TipMenu`/`TipItem` — tooltip system
   - `smStyleManager` — display styling and compact mode
   - Color helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,8 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
   - Monitors page: dynamic monitor list with add/delete/reorder, reads/writes `monitors` GSettings key
 - **`sampling.js`** (~570 lines): One moment and one read, shared across widgets
   - `smTickClock` — one `GLib` timer per distinct refresh interval, so widgets sharing an interval update in the same callback instead of drifting apart. `base.js`'s `restart_update_timer` registers here
-  - `Sampler` / `AsyncSampler` — one read of a shared source (`/proc/stat`, `/proc/diskstats`, `gpu_usage.sh`, `sensors -jA`, a Prometheus scrape), taken by whichever widget ticks first
+  - `Sampler` / `AsyncSampler` — one read of a shared source (`/proc/stat`, `/proc/diskstats`, `/proc/net/dev`, `gpu_usage.sh`, `sensors -jA`, a Prometheus scrape), taken by whichever widget ticks first
+  - A sampler shares the *decode*, not just the I/O: the CPU reading carries per-core columns, a scrape carries its split lines, and the net reading carries each interface's `edge` flag — whether it is where traffic enters or leaves the machine, which is what `net`'s `all` sums
   - `Cursor` — one widget's position in a sampler's readings; it never consumes the same reading twice, which is what keeps delta-based metrics honest
   - `smSamplers` — the per-extension registry, `extension._Samplers`
 - **`common.js`**: Shared utilities (`parse_bytearray()`, `check_sensors()`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,8 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
 - **`sampling.js`** (~570 lines): One moment and one read, shared across widgets
   - `smTickClock` — one `GLib` timer per distinct refresh interval, so widgets sharing an interval update in the same callback instead of drifting apart. `base.js`'s `restart_update_timer` registers here
   - `Sampler` / `AsyncSampler` — one read of a shared source (`/proc/stat`, `/proc/diskstats`, `/proc/net/dev`, `gpu_usage.sh`, `sensors -jA`, a Prometheus scrape), taken by whichever widget ticks first
-  - A sampler shares the *decode*, not just the I/O: the CPU reading carries per-core columns, a scrape carries its split lines, and the net reading carries each interface's `edge` flag — whether it is where traffic enters or leaves the machine, which is what `net`'s `all` sums
+  - A sampler shares the *decode*, not just the I/O: the CPU reading carries per-core columns, a scrape carries its split lines, the net reading carries each interface's `edge` flag — whether it is where traffic enters or leaves the machine, which is what `net`'s `all` sums — and the disk reading carries each device's `medium` flag, whether I/O to it reaches storage attached to this machine, which is what `disk`'s `all` sums
+  - Both flags come from `is_storage_medium()`/`markEdges()` testing for a `device` symlink in sysfs, the link the kernel creates from a driver to its hardware parent. They are named apart on purpose: an `nbd` device *is* where disk I/O leaves the machine and is exactly what `medium` excludes
   - `Cursor` — one widget's position in a sampler's readings; it never consumes the same reading twice, which is what keeps delta-based metrics honest
   - `smSamplers` — the per-extension registry, `extension._Samplers`
 - **`common.js`**: Shared utilities (`parse_bytearray()`, `check_sensors()`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,11 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
 - **`prefs.js`**: Preferences UI (GTK4/Adw)
   - General settings page (uses `ui/prefsGeneralSettings.ui` template)
   - Monitors page: dynamic monitor list with add/delete/reorder, reads/writes `monitors` GSettings key
+- **`sampling.js`** (~570 lines): One moment and one read, shared across widgets
+  - `smTickClock` — one `GLib` timer per distinct refresh interval, so widgets sharing an interval update in the same callback instead of drifting apart. `base.js`'s `restart_update_timer` registers here
+  - `Sampler` / `AsyncSampler` — one read of a shared source (`/proc/stat`, `/proc/diskstats`, `gpu_usage.sh`, `sensors -jA`, a Prometheus scrape), taken by whichever widget ticks first
+  - `Cursor` — one widget's position in a sampler's readings; it never consumes the same reading twice, which is what keeps delta-based metrics honest
+  - `smSamplers` — the per-extension registry, `extension._Samplers`
 - **`common.js`**: Shared utilities (`parse_bytearray()`, `check_sensors()`)
 - **`utils.js`**: Logging (`sm_log()`)
 - **`migration.js`**: Settings schema migration (v0 → v1 → v2)
@@ -232,7 +237,7 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
 
 ### External Resources
 
-- **`gpu_usage.sh`**: Shell script for GPU monitoring (NVIDIA via `nvidia-smi`, AMD via sysfs); accepts GPU index as `$1`
+- **`gpu_usage.sh`**: Shell script for GPU monitoring (NVIDIA via `nvidia-smi`, AMD via sysfs). Takes no arguments and prints one line per GPU: `<index> <total MiB> <used MiB> <busy %>`. Both the panel and the preferences GPU picker enumerate from it, so it is the single source of truth for which GPUs exist
 - **`stylesheet.css`**: Extension styling
 
 ### Monitoring Architecture
@@ -241,7 +246,7 @@ The extension follows a config-driven modular pattern:
 1. On startup, `migration.js` converts legacy per-widget GSettings into a JSON `monitors` array (if needed)
 2. `extension.js` reads `monitors`, normalizes and expands it via `monitors.js` into one config per device, looks up each config's `type` in `WIDGET_CLASSES`, and instantiates widgets with their config object
 3. Each widget class in `widgets/` extends `ElementBase` from `base.js`, declares `static metadata` (identity, metrics, units), and uses `this.config` for per-instance settings
-4. `ElementBase` handles shared concerns: config-driven initialization, update timers, chart rendering, tooltips, panel/menu item creation
+4. `ElementBase` handles shared concerns: config-driven initialization, chart rendering, tooltips, panel/menu item creation. It does not own a refresh timer — it registers with `smTickClock`, so every widget on the same interval updates in one callback
 5. Simple widgets implement `collect()` returning `{metricKey: value}`; complex widgets use `refresh()` + `_apply()`
 6. `this.device_id` (from `config.device`) enables per-device monitoring — e.g. individual CPU cores, specific network interfaces, or GPU indices
 7. When the `monitors` GSettings key changes, `_syncMonitors()` dynamically adds/removes/updates widgets without restarting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,9 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
 - **`extension.js`** (~300 lines): Extension lifecycle (enable/disable), config-driven widget instantiation
   - `WIDGET_CLASSES` lookup table maps type strings to constructors
   - `_syncMonitors()` handles live add/remove/reorder when `monitors` setting changes
+- **`monitors.js`** (~160 lines): The config boundary — the only place monitor configs are built
+  - `parseMonitorConfigs()` normalizes the `monitors` setting; skips what it cannot repair
+  - `expandMonitor()` turns one config into one derived config per selected device
 - **`base.js`** (~900 lines): Widget framework
   - `ElementBase` — base class for all monitoring widgets; accepts `(extension, config)` constructor
   - `onSettingsChanged(newConfig)` for live config updates without recreating widgets
@@ -206,21 +209,23 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
   - **`monitors` key** (type `as`): JSON array of widget configurations — the primary config mechanism
   - Legacy per-widget keys (`{metric}-{property}`) remain for backward compat
 
-- **Monitor config object shape** (each widget instance gets one):
+- **Monitor config object shape** (one per preferences entry; expands to one widget per device):
   ```json
   {
     "uuid": "unique-id",
     "type": "cpu",
-    "device": "all",
+    "devices": [{"id": "all", "show-text": true}, {"id": "0", "show-text": false}],
     "display": true,
     "style": "graph",
     "graph-width": 100,
     "refresh-time": 1500,
-    "show-text": true,
     "show-menu": true,
     "colors": {"user": "#0072b3", "system": "#0092e6"}
   }
   ```
+  `devices` also accepts a bare id list (`["all", "0", "1"]`) and the legacy scalar
+  `"device": "all"`; both normalize on load. An entry's keys beyond `id` are a sparse
+  override of the shared body for that device only.
 
 - **Display styles:** Each metric supports `digit`, `graph`, or `both` modes
 - **Disk usage styles:** `pie`, `bar`, or `none`
@@ -234,7 +239,7 @@ All extension source files are in `system-monitor-next@paradoxxx.zero.gmail.com/
 
 The extension follows a config-driven modular pattern:
 1. On startup, `migration.js` converts legacy per-widget GSettings into a JSON `monitors` array (if needed)
-2. `extension.js` reads `monitors`, looks up each config's `type` in `WIDGET_CLASSES`, and instantiates widgets with their config object
+2. `extension.js` reads `monitors`, normalizes and expands it via `monitors.js` into one config per device, looks up each config's `type` in `WIDGET_CLASSES`, and instantiates widgets with their config object
 3. Each widget class in `widgets/` extends `ElementBase` from `base.js`, declares `static metadata` (identity, metrics, units), and uses `this.config` for per-instance settings
 4. `ElementBase` handles shared concerns: config-driven initialization, update timers, chart rendering, tooltips, panel/menu item creation
 5. Simple widgets implement `collect()` returning `{metricKey: value}`; complex widgets use `refresh()` + `_apply()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ A GNOME Shell extension that displays system resource usage (CPU, memory, disk, 
 
 The extension requires system libraries to function:
 - `libgtop` (system metrics)
-- `NetworkManager` libraries (network monitoring)
 - `clutter` (rendering)
 - `gnome-system-monitor`
 - For NVIDIA GPU monitoring: `nvidia-smi`

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BASE_MODULES = \
   $(UUID)/mounts.js \
   $(UUID)/utils.js \
   $(UUID)/migration.js \
+  $(UUID)/monitors.js \
   $(UUID)/common.js \
   $(UUID)/README* \
   $(UUID)/metadata.json \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ BASE_MODULES = \
   $(UUID)/utils.js \
   $(UUID)/migration.js \
   $(UUID)/monitors.js \
+  $(UUID)/sampling.js \
   $(UUID)/common.js \
   $(UUID)/README* \
   $(UUID)/metadata.json \

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ A GNOME Shell extension that displays system resource usage in the top panel.
 
 ![Standard View](screenshots/standard.png)
 
+**A figure on your panel changed after an update?** [CHANGELOG.md](CHANGELOG.md)
+says which way it moved and why.
+
 ## Table of Contents
 
+- [Changelog](CHANGELOG.md)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
   - [Browser Installation](#browser-installation)

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Before installing, ensure you have the necessary system packages (note that if y
 
 - Ubuntu/Debian:
   ```
-  sudo apt install gir1.2-gtop-2.0 gir1.2-nm-1.0 gir1.2-clutter-1.0 gnome-system-monitor
+  sudo apt install gir1.2-gtop-2.0 gir1.2-clutter-1.0 gnome-system-monitor
   ```
 
 - Fedora:
   ```
-  sudo dnf install libgtop2-devel NetworkManager-libnm-devel gnome-system-monitor
+  sudo dnf install libgtop2-devel gnome-system-monitor
   ```
 
 - Arch Linux:
@@ -50,11 +50,11 @@ Before installing, ensure you have the necessary system packages (note that if y
 
 - Mageia 64-bit:
   ```
-  sudo urpmi lib64gtop-gir2.0 lib64nm-gir1.0 lib64clutter-gir1.0 gnome-system-monitor
+  sudo urpmi lib64gtop-gir2.0 lib64clutter-gir1.0 gnome-system-monitor
   ```
   or
   ```
-  sudo dnf install lib64gtop-gir2.0 lib64nm-gir1.0 lib64clutter-gir1.0 gnome-system-monitor
+  sudo dnf install lib64gtop-gir2.0 lib64clutter-gir1.0 gnome-system-monitor
   ```
 
 - NixOS:

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -243,7 +243,49 @@ After `super(extension, config)`, these are available:
 
 ## Multi-Device Support
 
-Widgets support monitoring specific devices via `this.device_id`. The config's `device` field determines which device to monitor:
+A monitor config covers a **set** of devices, and the framework expands it into one widget per device before any widget is constructed. Widgets are unaffected by this: each one still monitors exactly one device and reads it from `this.device_id`.
+
+```json
+{
+  "uuid": "a1b2c3", "type": "cpu",
+  "devices": ["all", "0", "1", "2", "3"],
+  "style": "graph", "graph-width": 20
+}
+```
+
+That is one entry in preferences and five widgets in the panel. `"all"` is a device id like the others, meaning *the aggregate* — the total across every core — so "total plus each core" is a single selection.
+
+A device entry may also be an object, in which case its extra keys override the shared body for that device alone:
+
+```json
+"devices": [
+  {"id": "all", "show-text": true},
+  {"id": "0", "show-text": false},
+  {"id": "1", "show-text": false}
+]
+```
+
+Preferences writes this longer form and only ever puts `show-text` in it, but any config key works — the override is a plain sparse patch applied over the shared settings.
+
+Writing configs by hand (for a test preset, say), the bare list of ids is enough. The older single-`device` form still loads too:
+
+```json
+{"uuid": "cfg-cpu", "type": "cpu", "device": "all"}
+```
+
+### What a widget sees
+
+Each expanded widget receives a config with `device` set to its own id, so nothing in a widget changes. Two extra fields identify where it came from:
+
+| Field         | Description                                                  |
+|---------------|--------------------------------------------------------------|
+| `device`      | This widget's device id — what `this.device_id` reads         |
+| `monitorUuid` | The uuid of the preferences entry that produced this widget    |
+| `uuid`        | Internal widget key; not addressable by the user, do not log it |
+
+A widget's device never changes over its lifetime. The widget key is derived from (monitor uuid, device id), so changing which devices a monitor covers adds and removes widgets rather than mutating one — which is why `device_id` can be cached in the constructor.
+
+The config's `device` field determines which device to monitor:
 
 ```javascript
 constructor(extension, config) {
@@ -266,7 +308,21 @@ Common device_id patterns:
 - `'0'`, `'1'`, ... — indexed device (CPU core, GPU index)
 - Sensor label string — named device (thermal/fan sensors)
 
-Users add multi-device instances through the preferences "Add Monitor" dialog.
+Users pick devices from a checklist in the preferences "Add Monitor" dialog, and can change the selection later from the monitor's row.
+
+### Declaring a new type's devices
+
+Preferences builds that checklist from `detectCatalog(type)` in `prefs.js`, which returns one of two shapes:
+
+```javascript
+// Nothing to choose: the source is the machine itself (memory, swap, battery)
+{kind: 'singleton', device: {id: 'default', name: 'Default'}}
+
+// A set of members, optionally with a total folded over them
+{kind: 'set', aggregate: {id: 'all', name: 'All cores (total)'}, members: [{id: '0', name: 'Core 1'}, ...]}
+```
+
+Use `aggregate: null` when the type has no meaningful total (GPUs, thermal sensors, fans). Members carry a display name because a checklist reading "0 1 2 3" is unusable — and if detection cannot confirm a device but the widget might still work with it, keep the entry and say so in its name rather than presenting it as found.
 
 ## Declarative Layouts
 
@@ -342,7 +398,7 @@ After writing the widget class, register it with the extension:
        loadavg: LoadAvg,
    };
    ```
-4. Add the type to `MONITOR_TYPES` in `prefs.js` and provide entries in `COLOR_MAP`, `DEFAULT_COLORS`, and `detectDevices()` for the new type
+4. Add the type to `MONITOR_TYPES` in `prefs.js` and provide entries in `TYPE_NAMES`, `COLOR_MAP`, `DEFAULT_COLORS`, and `detectCatalog()` for the new type
 5. Add color key(s) to the schema XML if the widget has configurable colors
 
 ## Examples by Complexity

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -202,9 +202,32 @@ collectAsync(callback) {
 }
 ```
 
-Call `callback(data)` when the data is ready, or `callback(null)` if the read failed. The framework handles chart/tooltip updates after the callback fires.
+Call `callback(data)` when the data is ready. The framework handles chart/tooltip updates after the callback fires.
 
 **Do not implement both `collect()` and `refresh()`** — the framework checks for `collect` first and ignores `refresh`/`_apply` if it exists.
+
+### There is no reading
+
+A tick yields one of two things, and there is no third:
+
+| Return | Meaning |
+|--------|---------|
+| a data object | numbers, applied as above |
+| `null` | **there is no reading** |
+
+Return `null` whenever you have no numbers — the device you were configured to watch is not in the source, the source could not be read, the first reading has not landed yet. The framework writes `--` into the panel digits, the menu cells and the tooltip, and the chart takes a **hole** for that tick rather than a zero.
+
+Do not build your own `'--'`, and do not return a data object with the metrics left out. Three widgets each did that independently and each got it subtly wrong — a chart that kept drawing the last value under dashes, a menu unit with nothing in front of it.
+
+Two rules that come with it:
+
+- **An aggregate is never "no reading".** A device named `all` is a fold over a set, and the empty set folds to zero, which is a measurement. Only a *named* device can be absent.
+- **Say which one in the journal, once per outage.** `--` tells the user there is no number; only the journal can tell them why. Name the device the user asked for, name what the source did list, and say what is being shown instead — that last clause is what separates a bad selection from a bad machine:
+
+```javascript
+sm_log(`${this.item_name}: /proc/diskstats lists ${[...devices.keys()].join(', ')} — ` +
+       `nothing for "${this.device_id}". Showing --.`, 'warn');
+```
 
 ## Sharing a source between widgets
 

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -206,6 +206,35 @@ Call `callback(data)` when the data is ready, or `callback(null)` if the read fa
 
 **Do not implement both `collect()` and `refresh()`** — the framework checks for `collect` first and ignores `refresh`/`_apply` if it exists.
 
+## Sharing a source between widgets
+
+If your source contains data for more than one device — `/proc/stat` holds every core, one `nvidia-smi` call covers every GPU, one scrape covers every metric on a server — do not read it per widget. Take a cursor on a shared sampler in `sampling.js`, and whichever widget's tick fires first pays for the read while the rest ride it.
+
+| Your widget uses | Take a cursor on | Where |
+|------------------|------------------|-------|
+| `collect()`      | `Sampler`        | `extension._Samplers.<name>.cursor()` |
+| `collectAsync()` | `AsyncSampler`   | same, then `cursor.sample(reading => …)` |
+
+```javascript
+constructor(extension, config) {
+    super(extension, config);
+    this.cursor = extension._Samplers.cpu.cursor();   // once, here
+}
+
+collect() {
+    const reading = this.cursor.sample();             // {gen, time, data}
+    return { load1: reading.data.core(this.cpuid).user };
+}
+```
+
+Three rules:
+
+- **Use `reading.time` for rate arithmetic, never the clock at delivery.** A reading taken for a faster sibling is older than your tick, and dividing a real counter delta by the wrong interval reports the wrong rate. This is the one every widget in the tree got wrong before sampling existed, so it is the one you will copy wrong from the file next door.
+- **Add a new shared source as a getter on `smSamplers`**, not as a module-level cache of its own. One place to look, one lifetime, one teardown.
+- **Do not add your own `GLib.timeout_add` for refreshing.** `refresh-time` is served by a timer shared with every other widget on that interval, so a private one puts your widget out of step with the rest of the panel.
+
+A sampler owns the read; it does not own a timer. Widgets keep their own tick and a cursor never repeats a reading, so a widget never sees data older than its own configured refresh interval.
+
 ## Constructor
 
 Most simple widgets don't need a constructor at all — the framework handles initialization and schedules the first data update automatically.

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -260,7 +260,9 @@ After `super(extension, config)`, these are available:
 | `this.config`     | Per-instance config object (display, style, colors, refresh-time, etc.)      |
 | `this.device_id`  | Device identifier from `config.device` (`'all'`, `'0'`, sensor label, etc.)  |
 | `this.extension`  | The extension instance                                                       |
-| `this.item_name`  | Display name (from `metadata.name`, can be overridden)                       |
+| `this.item_name`  | Popup menu title when this widget is a monitor's only device (can be overridden) |
+| `this.device_name`| Popup menu label when it is one of several (defaults to `device_id`)         |
+| `this.monitor_name`| The type's own name, from `metadata.name` — the title over a monitor's devices |
 | `this.label`      | `St.Label` — the panel label widget (text set from metadata, can be changed) |
 | `this.text_items` | Array of `St.Label`/`St.Icon` — panel value display elements                 |
 | `this.menu_items` | Array of `St.Label` — popup menu display elements                            |
@@ -327,6 +329,7 @@ constructor(extension, config) {
         this.coreIndex = parseInt(this.device_id);
         this.label.text = 'CPU' + (this.coreIndex + 1);
         this.item_name = _('CPU') + ' ' + (this.coreIndex + 1);
+        this.device_name = String(this.coreIndex + 1);
     }
 }
 ```
@@ -338,6 +341,22 @@ Common device_id patterns:
 - Sensor label string — named device (thermal/fan sensors)
 
 Users pick devices from a checklist in the preferences "Add Monitor" dialog, and can change the selection later from the monitor's row.
+
+### How a monitor's devices reach the popup menu
+
+The menu has **one entry per monitor**, not one row per widget. A monitor with one visible device is a plain row titled `item_name`; a monitor with several writes its type once and then each device beside its own numbers, wrapped over as many lines as they need:
+
+```
+CPU     All: 3 %   1: 1 %   2: 5 %   3: 2 %
+        4: 7 %
+Net     enp1s0: 12 KiB/s ↓  3 KiB/s ↑
+```
+
+So a widget sets `item_name` for the first case and `device_name` for the second. `device_name` defaults to the device id, which is already the right answer wherever the id *is* the name — interfaces, block devices, sensor labels, GPU indices — and to `All` for the aggregate, matching the word the preferences picker uses. Override it only when the id is not the name: `cpu` and `freq` do, because their ids count from zero and their names count from one.
+
+`item_name` is not derived from the other two, and should not be: `thermal` and `fan` use the sensor label with no type in front of it, and `prometheus` uses the metric from its config, so what belongs in a title is the widget's own decision.
+
+A widget's `menu_items` are its own for its whole life — the menu borrows them, and gives them back before it rebuilds — so `_applyMenu` writes to the same labels whichever shape the entry has.
 
 ### Declaring a new type's devices
 

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -353,6 +353,14 @@ Preferences builds that checklist from `detectCatalog(type)` in `prefs.js`, whic
 
 Use `aggregate: null` when the type has no meaningful total (GPUs, thermal sensors, fans). Members carry a display name because a checklist reading "0 1 2 3" is unusable — and if detection cannot confirm a device but the widget might still work with it, keep the entry and say so in its name rather than presenting it as found.
 
+An aggregate may carry a `note`, which replaces the row's default subtitle ("Combined figure for every device"):
+
+```javascript
+{id: 'all', name: 'All physical interfaces (total)', note: 'Excludes VPN, bridge and container interfaces — …'}
+```
+
+Reach for it only when the total is *not* a plain fold over the members listed beneath it. `net` is the one such type: it sums the interfaces at the machine's edge, because counting a tunnel and the hardware carrying it reports the same bytes twice. A user who sees a checklist of eight interfaces under a row labelled "all" and gets the sum of two has been lied to unless the row says so.
+
 ## Declarative Layouts
 
 The framework builds panel and menu UI from metadata declarations. Widget authors declare layout intent; the framework builds the labels and populates them from `collect()` return keys.

--- a/docs/widget-authoring.md
+++ b/docs/widget-authoring.md
@@ -401,7 +401,12 @@ An aggregate may carry a `note`, which replaces the row's default subtitle ("Com
 {id: 'all', name: 'All physical interfaces (total)', note: 'Excludes VPN, bridge and container interfaces — …'}
 ```
 
-Reach for it only when the total is *not* a plain fold over the members listed beneath it. `net` is the one such type: it sums the interfaces at the machine's edge, because counting a tunnel and the hardware carrying it reports the same bytes twice. A user who sees a checklist of eight interfaces under a row labelled "all" and gets the sum of two has been lied to unless the row says so.
+Reach for it only when the total is *not* a plain fold over the members listed beneath it. Two types are like that, and for the same reason — both traffic and block I/O are layered, so the same bytes appear at more than one member:
+
+- `net` sums the interfaces at the machine's edge, because counting a tunnel and the hardware carrying it reports the same bytes twice.
+- `disk` sums the devices where I/O reaches physical storage, because the block layer accounts a request at every device it traverses — the logical volume, the encrypted device under it, the partition, and the disk.
+
+A user who sees a checklist of eight devices under a row labelled "all" and gets the sum of two has been lied to unless the row says so. Where the members are layered, order the summed ones first: the aggregate's claim then becomes checkable by looking, and the excluded devices stay one click away for whoever wants the view from inside the tunnel or the encrypted volume.
 
 ## Declarative Layouts
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -56,6 +56,10 @@ function tr(text) {
     return text ? _(text) : '';
 }
 
+// A collect that never calls back is a bug in a widget, not a condition to
+// design around, so the recovery only has to be eventual rather than prompt.
+const ASYNC_STALL_US = 30 * 1e6;
+
 export function l_limit(t) {
     return (t > 0) ? t : 1000;
 }
@@ -932,33 +936,10 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
             if (this.collect) {
                 this._applyCollected(this.collect());
             } else if (this.collectAsync) {
-                if (!this._asyncPending) {
-                    this._asyncPending = true;
-                    const gen = ++this._asyncGen;
-                    if (this._asyncTimeoutId)
-                        GLib.Source.remove(this._asyncTimeoutId);
-                    this._asyncTimeoutId = GLib.timeout_add_seconds(
-                        GLib.PRIORITY_DEFAULT, 30, () => {
-                            this._asyncTimeoutId = null;
-                            if (this._asyncPending && this._asyncGen === gen) {
-                                sm_log(`${this.elt}: async collect timed out`, 'warn');
-                                this._asyncPending = false;
-                            }
-                            return GLib.SOURCE_REMOVE;
-                        });
-                    this.collectAsync(data => {
-                        if (this._asyncGen !== gen)
-                            return;
-                        this._asyncPending = false;
-                        if (this._asyncTimeoutId) {
-                            GLib.Source.remove(this._asyncTimeoutId);
-                            this._asyncTimeoutId = null;
-                        }
-                        if (this._destroyed)
-                            return;
-                        this._applyCollected(data);
-                    });
-                }
+                if (this._asyncPending)
+                    this._checkAsyncStall();
+                else
+                    this._startAsyncCollect();
             } else {
                 this.refresh();
                 this._apply();
@@ -968,6 +949,38 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         } catch (e) {
             this._logUpdateError(e);
         }
+    }
+    _startAsyncCollect() {
+        this._asyncPending = true;
+        this._asyncStartedAt = GLib.get_monotonic_time();
+        const gen = ++this._asyncGen;
+        try {
+            this.collectAsync(data => {
+                // A callback from a collect we already gave up on.
+                if (this._asyncGen !== gen)
+                    return;
+                this._asyncPending = false;
+                if (this._destroyed)
+                    return;
+                this._applyCollected(data);
+            });
+        } catch (e) {
+            // Nothing would ever clear the pending flag, and this widget would
+            // stop collecting for good.
+            this._asyncPending = false;
+            throw e;
+        }
+    }
+    // A collect that never calls back would leave this widget pending forever,
+    // so the stall is noticed at the next tick -- which costs nothing, where a
+    // GLib timeout armed and disarmed around every collect cost two source
+    // operations per widget per tick, paid forever to catch something that
+    // essentially never happens.
+    _checkAsyncStall() {
+        if (GLib.get_monotonic_time() - this._asyncStartedAt < ASYNC_STALL_US)
+            return;
+        sm_log(`${this.elt}: async collect did not finish; giving up on it`, 'warn');
+        this._asyncPending = false;
     }
     _applyCollected(data) {
         try {
@@ -1098,10 +1111,6 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         if (this.graph_scale_cooldown_timer_id) {
             GLib.Source.remove(this.graph_scale_cooldown_timer_id);
             this.graph_scale_cooldown_timer_id = null;
-        }
-        if (this._asyncTimeoutId) {
-            GLib.Source.remove(this._asyncTimeoutId);
-            this._asyncTimeoutId = null;
         }
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -423,15 +423,23 @@ export const Chart = class SystemMonitor_Chart {
         themeContext.connectObject('notify::scale-factor', this.rescale.bind(this), this);
         this.actor.connect('repaint', this._draw.bind(this));
     }
-    update() {
-        let data_a = this.parentC.vals;
-        if (data_a.length !== this.parentC.colors.length) {
+    /**
+     * @param {number[]|null} vals - this tick's values, or null when the tick
+     *   produced no reading. A null sample is a hole in the series rather than
+     *   a zero: the fill stops at it and resumes after it, where a zero would
+     *   draw a notch that reads as a real idle moment.
+     */
+    update(vals) {
+        const series = this.parentC.colors.length;
+        if (vals && vals.length !== series) {
             return;
         }
-        let accdata = [];
-        for (let l = 0; l < data_a.length; l++) {
-            accdata[l] = (l === 0) ? data_a[0] : accdata[l - 1] + ((data_a[l] > 0) ? data_a[l] : 0);
-            this.data[l].push(accdata[l]);
+        let acc = 0;
+        for (let l = 0; l < series; l++) {
+            if (vals) {
+                acc = (l === 0) ? vals[0] : acc + ((vals[l] > 0) ? vals[l] : 0);
+            }
+            this.data[l].push(vals ? acc : null);
             if (this.data[l].length > this.width) {
                 this.data[l].shift();
             }
@@ -470,29 +478,63 @@ export const Chart = class SystemMonitor_Chart {
         sm_cairo_set_source_color(cr, this.extension._Background);
         cr.rectangle(0, 0, width, height);
         cr.fill();
+        const frame = {cr, width, height, top, range, samples: this.data[0].length - 1};
         for (let i = this.parentC.colors.length - 1; i >= 0; i--) {
-            let samples = this.data[i].length - 1;
-            if (samples > 0) {
-                cr.moveTo(width, height); // bottom right
-                let x = width - 0.25 * this.scale_factor;
-                cr.lineTo(x, (top - this.data[i][samples] / range) * height);
-                x -= 0.5 * this.scale_factor;
-                for (let j = samples; j >= 0; j--) {
-                    let y = (top - this.data[i][j] / range) * height;
-                    cr.lineTo(x, y);
-                    x -= 0.5 * this.scale_factor;
-                    cr.lineTo(x, y);
-                    x -= 0.5 * this.scale_factor;
-                }
-                x += 0.25 * this.scale_factor;
-                cr.lineTo(x, (top - this.data[i][0] / range) * height);
-                cr.lineTo(x, height);
-                cr.closePath();
-                sm_cairo_set_source_color(cr, this.parentC.colors[i]);
-                cr.fill();
+            if (frame.samples <= 0) {
+                continue;
             }
+            sm_cairo_set_source_color(cr, this.parentC.colors[i]);
+            this._fill_series(frame, this.data[i]);
         }
         cr.$dispose();
+    }
+    // Right to left, filling each run of present samples as its own closed
+    // shape, so that a tick with no reading leaves a hole rather than a notch
+    // at the floor. Invariant: `newest` is the index of the most recent sample
+    // of the run being collected, or -1 between runs.
+    _fill_series(frame, series) {
+        let newest = -1;
+        for (let j = frame.samples; j >= 0; j--) {
+            if (series[j] === null) {
+                if (newest >= 0) {
+                    this._fill_run(frame, series, newest, j + 1);
+                    newest = -1;
+                }
+                continue;
+            }
+            if (newest < 0) {
+                newest = j;
+            }
+            if (j === 0) {
+                this._fill_run(frame, series, newest, 0);
+            }
+        }
+    }
+    // A sample's position is fixed by its index -- every sample takes one cell,
+    // holes included -- so a run's geometry does not depend on what preceded it,
+    // and a series with no holes traces exactly the path this chart has always
+    // traced.
+    _fill_run(frame, series, newest, oldest) {
+        const {cr, height} = frame;
+        const step = 0.5 * this.scale_factor;
+        const y = j => (frame.top - series[j] / frame.range) * height;
+        let x = frame.width - (frame.samples - newest) * 2 * step;
+        cr.moveTo(x, height); // the run's bottom right
+        x -= 0.5 * step;
+        cr.lineTo(x, y(newest));
+        x -= step;
+        for (let j = newest; j >= oldest; j--) {
+            const yj = y(j);
+            cr.lineTo(x, yj);
+            x -= step;
+            cr.lineTo(x, yj);
+            x -= step;
+        }
+        x += 0.5 * step;
+        cr.lineTo(x, y(oldest));
+        cr.lineTo(x, height);
+        cr.closePath();
+        cr.fill();
     }
     resize(width) {
         if (this.width === width) {
@@ -1114,7 +1156,7 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
             } else {
                 this.refresh();
                 this._apply();
-                this._postApply();
+                this._postApply(this.vals);
                 this._updateErrorLogged = false;
             }
         } catch (e) {
@@ -1157,7 +1199,7 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         try {
             if (data)
                 this._autoApply(data);
-            this._postApply();
+            this._postApply(this.vals);
             this._updateErrorLogged = false;
         } catch (e) {
             this._logUpdateError(e);
@@ -1169,8 +1211,12 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         this._updateErrorLogged = true;
         sm_log(`${this.elt}: update failed: ${e}`, 'error');
     }
-    _postApply() {
-        this.chart.update();
+    /**
+     * @param {number[]|null} vals - this tick's values, or null when the tick
+     *   produced no reading, which the chart draws as a hole.
+     */
+    _postApply(vals) {
+        this.chart.update(vals);
         for (let i = 0; i < this.tip_vals.length; i++) {
             if (this.tip_labels[i])
                 this.tip_labels[i].text = this.tip_vals[i].toString();

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -60,6 +60,18 @@ function tr(text) {
 // design around, so the recovery only has to be eventual rather than prompt.
 const ASYNC_STALL_US = 30 * 1e6;
 
+// The device id every widget already branches on to mean "the total over all of
+// them", named here so the menu can say it in the word preferences uses.
+const AGGREGATE_DEVICE = 'all';
+
+// What a device is called when its widget does not say otherwise. Right
+// wherever the id is already the name -- interfaces, block devices, sensor
+// labels, GPU indices -- and 'All' for the total, which is the word the
+// preferences picker uses, so the name resolves when a user goes looking.
+function default_device_name(deviceId) {
+    return deviceId === AGGREGATE_DEVICE ? _('All') : deviceId;
+}
+
 export function l_limit(t) {
     return (t > 0) ? t : 1000;
 }
@@ -626,6 +638,17 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
      * Constructor receives a config object with per-instance settings:
      *   { uuid, type, device, display, style, graph-width, refresh-time,
      *     show-text, show-menu, colors, ... }
+     *
+     * Three names. A widget may set the first two in its constructor; the third
+     * is the type's own name and is not a widget's to change:
+     *   item_name    - the popup menu row when this widget is a monitor's only
+     *                  device. Folds type and device together however the widget
+     *                  sees fit: 'CPU 4', but 'Package id 0' with no type at all.
+     *   device_name  - the cell when the monitor covers several devices, where
+     *                  the type is already written once beside them. Defaults to
+     *                  the device id, which is right wherever the id is already
+     *                  the name (interfaces, block devices, sensor labels).
+     *   monitor_name - the title over those cells.
      */
     constructor(extension, config) {
         super(extension);
@@ -634,9 +657,14 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         const meta = this.constructor.metadata;
 
         this.elt = meta?.id || meta?.name?.toLowerCase() || config.type;
-        this.item_name = meta ? tr(meta.name) : '';
+        this.monitor_name = meta ? tr(meta.name) : '';
+        this.item_name = this.monitor_name;
         this.color_name = meta ? meta.metrics.filter(m => m.color).map(m => m.key) : [];
         this.device_id = config.device;
+        // The device's own name, for when this widget is one of several in a
+        // monitor and item_name -- which folds the type and the device together
+        // however that widget sees fit -- is the wrong half to show.
+        this.device_name = default_device_name(config.device);
         this.text_items = [];
         this.menu_items = [];
         this.menu_visible = true;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -60,6 +60,11 @@ function tr(text) {
 // design around, so the recovery only has to be eventual rather than prompt.
 const ASYNC_STALL_US = 30 * 1e6;
 
+// What the panel shows in place of a number it does not have. Not a zero: zero
+// is a measurement, and a device that is not on this machine has not been
+// measured.
+const NO_READING = '--';
+
 // The device id every widget already branches on to mean "the total over all of
 // them", named here so the menu can say it in the word preferences uses.
 const AGGREGATE_DEVICE = 'all';
@@ -1199,11 +1204,29 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         try {
             if (data)
                 this._autoApply(data);
-            this._postApply(this.vals);
+            else
+                this._showNoReading();
+            // This tick's values, or nothing at all: a tick with no reading is
+            // a hole in the series, never a zero.
+            this._postApply(data ? this.vals : null);
             this._updateErrorLogged = false;
         } catch (e) {
             this._logUpdateError(e);
         }
+    }
+    // A tick that produced no numbers: this widget's device is not in the
+    // source, the source could not be read, or the first reading has not landed
+    // yet. One form for all three, because which of them it was is a journal
+    // question and the panel's answer is the same either way -- there is no
+    // number. Units are left alone, since "-- KiB/s" still says what the number
+    // would have been.
+    _showNoReading() {
+        const meta = this.constructor.metadata;
+        const data = {display: NO_READING, display2: NO_READING, detail: NO_READING};
+        for (let i = 0; i < this.tip_vals.length; i++)
+            this.tip_vals[i] = NO_READING;
+        this._applyPanel(data, NO_READING, meta?.panelLayout ?? 'simple');
+        this._applyMenu(data, NO_READING, meta?.menuLayout ?? 'simple');
     }
     _logUpdateError(e) {
         if (this._updateErrorLogged)

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -64,6 +64,12 @@ const ASYNC_STALL_US = 30 * 1e6;
 // them", named here so the menu can say it in the word preferences uses.
 const AGGREGATE_DEVICE = 'all';
 
+// How much width a monitor's devices may take in the popup menu, before the
+// theme's scale factor. The menu is about 390px wide with a title column of
+// roughly 100, and it is the menu's *height* that runs out -- so this buys
+// lines back without letting the menu grow sideways to pay for them.
+const MENU_ENTRY_WIDTH = 280;
+
 // What a device is called when its widget does not say otherwise. Right
 // wherever the id is already the name -- interfaces, block devices, sensor
 // labels, GPU indices -- and 'All' for the total, which is the word the
@@ -99,6 +105,126 @@ function release_menu_cells(elts) {
     }
 }
 
+// One entry per monitor, in the order the monitor's first widget appears.
+// Grouping is a Map rather than a run detector: a monitor's widgets are
+// adjacent in elts today, but that is expansion's ordering, held across a
+// module boundary with nothing here enforcing it. Gathering costs the same and
+// beats emitting two entries under the same title if it ever stops holding.
+//
+// Hidden widgets are dropped here, so an entry always has at least one device
+// and a monitor whose devices are all hidden contributes nothing.
+function group_by_monitor(elts) {
+    const entries = new Map();
+    for (const widget of elts) {
+        if (!widget.menu_visible)
+            continue;
+        const devices = entries.get(widget.config.monitorUuid);
+        if (devices)
+            devices.push(widget);
+        else
+            entries.set(widget.config.monitorUuid, [widget]);
+    }
+    return entries;
+}
+
+// A monitor's devices under one title. The wrap is not decided here: a cell is
+// as wide as the number in it, and the numbers arrive on each widget's own tick.
+// Deciding at build time would decide on whatever the values happened to be --
+// on the first build, on no values at all -- so the cells go in one column and
+// reflow_menu_entries settles them whenever the menu is opened.
+function build_monitor_entry(extension, devices) {
+    const Style = extension._Style;
+    const entry = new St.BoxLayout({style: 'spacing: 10px;'});
+    entry.add_child(new St.Label({
+        text: devices[0].monitor_name,
+        style_class: Style.get('sm-title'),
+        x_align: Clutter.ActorAlign.START,
+        y_align: Clutter.ActorAlign.CENTER
+    }));
+
+    // Homogeneous, so every device occupies the same width and the values line
+    // up in a lattice. Legitimate because a monitor is one type: every device
+    // in it has the same menuLayout and therefore the same cells.
+    const grid = new St.Widget({
+        style: 'spacing-rows: 2px; spacing-columns: 18px;',
+        layout_manager: new Clutter.GridLayout({orientation: Clutter.Orientation.VERTICAL})
+    });
+    grid.layout_manager.column_homogeneous = true;
+    entry.add_child(grid);
+
+    const cells = devices.map((widget, i) => {
+        const cell = new St.BoxLayout({style_class: 'sm-menu-device'});
+        // The colon is what keeps a numeric device name from reading as part of
+        // the number beside it: a core called 1 showing 3% is "1: 3 %", where
+        // "1 3 %" is a glance away from thirteen percent.
+        cell.add_child(new St.Label({
+            text: widget.device_name + ':',
+            style_class: Style.get('sm-device-name'),
+            y_align: Clutter.ActorAlign.CENTER
+        }));
+        for (const item of widget.menu_items)
+            cell.add_child(item);
+        // Every cell is as wide as the widest, and the slack has to fall
+        // somewhere. Falling inside a cell, it separates a device's name from
+        // its own number by more than the cells are separated from each other,
+        // and "1  0 %" beside "2  0 %" reads as "0 %1" -- the next device's
+        // name attaching itself to the previous device's value. So it falls
+        // here, after the cell, where the eye is meant to break anyway.
+        cell.add_child(new St.Widget({x_expand: true}));
+        grid.layout_manager.attach(cell, 0, i, 1, 1);
+        return cell;
+    });
+
+    return {actor: entry, grid, cells, columns: 1};
+}
+
+// Wrap the devices to the width budget. Placement is arithmetic rather than a
+// loop over an evolving line, so there is nothing to argue terminates; the one
+// obligation is 1 <= columns <= cells.length, which max(1, min(...)) discharges
+// as long as the divide is finite -- and `> 0` is false for NaN too, so a cell
+// that cannot report a width yields one column rather than an empty entry.
+function reflow_monitor_entry({grid, cells, columns}) {
+    const scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+    let widest = 0;
+    for (const cell of cells)
+        widest = Math.max(widest, cell.get_preferred_width(-1)[1]);
+    const cell_width = widest > 0 ? widest : 1;
+    const wrap = Math.max(1, Math.min(cells.length,
+        Math.floor(MENU_ENTRY_WIDTH * scale / cell_width)));
+    if (wrap === columns)
+        return wrap;
+
+    grid.remove_all_children();
+    cells.forEach((cell, i) => {
+        grid.layout_manager.attach(cell, i % wrap, (i / wrap) | 0, 1, 1);
+    });
+    return wrap;
+}
+
+// Settle every multi-device entry against the widths its values have now.
+// Called when the menu opens, which is the only moment the answer matters and
+// the one moment every value is as current as it will ever be.
+export function reflow_menu_entries(extension) {
+    for (const entry of extension.__sm?.menu_entries ?? [])
+        entry.columns = reflow_monitor_entry(entry);
+}
+
+function attach_monitor_row(extension, layout, widget, row_index) {
+    layout.attach(
+        new St.Label({
+            text: widget.item_name,
+            style_class: extension._Style.get('sm-title'),
+            x_align: Clutter.ActorAlign.START,
+            y_align: Clutter.ActorAlign.CENTER
+        }), 0, row_index, 1, 1);
+
+    let col_index = 1;
+    for (const item of widget.menu_items) {
+        layout.attach(item, col_index, row_index, 1, 1);
+        col_index++;
+    }
+}
+
 export function build_menu_info(extension) {
     let elts = extension.__sm.elts;
     let tray_menu = extension.__sm.tray.menu;
@@ -117,34 +243,33 @@ export function build_menu_info(extension) {
     });
     let menu_info_box_table_layout = menu_info_box_table.layout_manager;
 
-    // Populate Table
+    const entries = group_by_monitor(elts);
+    // One title column plus the widest set of cells in this table. Derived
+    // rather than written down, so a menuLayout added later cannot silently
+    // outgrow it, and seeded with 1 so an empty table needs no special case.
+    let table_columns = 1;
+    for (const devices of entries.values()) {
+        for (const widget of devices)
+            table_columns = Math.max(table_columns, 1 + widget.menu_items.length);
+    }
+
+    // A monitor with one visible device is the row it has always been: the
+    // title folds the device into itself, which two devices cannot both do.
     let row_index = 0;
-    for (let elt in elts) {
-        if (!elts[elt].menu_visible) {
-            continue;
+    extension.__sm.menu_entries = [];
+    for (const devices of entries.values()) {
+        if (devices.length === 1) {
+            attach_monitor_row(extension, menu_info_box_table_layout, devices[0], row_index);
+        } else {
+            const entry = build_monitor_entry(extension, devices);
+            menu_info_box_table_layout.attach(entry.actor, 0, row_index, table_columns, 1);
+            extension.__sm.menu_entries.push(entry);
         }
-
-        // Add item name to table
-        menu_info_box_table_layout.attach(
-            new St.Label({
-                text: elts[elt].item_name,
-                style_class: extension._Style.get('sm-title'),
-                x_align: Clutter.ActorAlign.START,
-                y_align: Clutter.ActorAlign.CENTER
-            }), 0, row_index, 1, 1);
-
-        // Add item data to table
-        let col_index = 1;
-        for (let item in elts[elt].menu_items) {
-            menu_info_box_table_layout.attach(
-                elts[elt].menu_items[item], col_index, row_index, 1, 1);
-
-            col_index++;
-        }
-
         row_index++;
     }
-    tray_menu._getMenuItems()[0].actor.get_last_child().add_child(menu_info_box_table);
+    lastChild.add_child(menu_info_box_table);
+    // A cell can only report its width once it is in the stage, which it now is.
+    reflow_menu_entries(extension);
 }
 
 export function change_menu() {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -626,7 +626,6 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         this.text_items = [];
         this.menu_items = [];
         this.menu_visible = true;
-        this.timeout = null;
         this._updateErrorLogged = false;
         this._asyncGen = 0;
 
@@ -877,21 +876,11 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
                 });
         }
     }
-    restart_update_timer(interval = null) {
-        interval = interval || this._lastInterval;
-        if (!interval) {
-            sm_log("Invalid call to restart_update_timer", 'error');
-            return;
-        }
-        if (this.timeout) {
-            GLib.Source.remove(this.timeout);
-        }
-        this.timeout = GLib.timeout_add(
-            GLib.PRIORITY_DEFAULT_IDLE,
-            interval,
-            this.update.bind(this),
-        );
-        this._lastInterval = interval;
+    // A widget does not own its refresh timer: it joins the one shared by every
+    // widget on the same interval, so siblings step together instead of drifting
+    // apart from whatever phase their construction order gave them.
+    restart_update_timer(interval) {
+        this.extension._Ticks.register(this, interval);
     }
     tip_format(unit) {
         if (typeof (unit) === 'undefined') {
@@ -928,15 +917,17 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
     //           this.tip_unit_labels[i].text = unit[i];
     //           }
     //           }
+    // Called by the shared tick for this widget's refresh interval, and once
+    // at construction so a newly added widget is not blank until that tick.
     update() {
         if (this._destroyed)
-            return GLib.SOURCE_REMOVE;
+            return;
+        // A hidden widget collects nothing, so it also forces no shared read.
         if (!this.menu_visible && !this.actor.visible) {
-            return GLib.SOURCE_CONTINUE;
+            return;
         }
-        // A throw escaping a GLib source callback removes the source, which
-        // would silently stop this widget's updates until shell restart —
-        // never let collection errors propagate out of here.
+        // A throw escaping here would take down every widget sharing this
+        // tick, not just this one -- never let collection errors propagate.
         try {
             if (this.collect) {
                 this._applyCollected(this.collect());
@@ -977,7 +968,6 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         } catch (e) {
             this._logUpdateError(e);
         }
-        return GLib.SOURCE_CONTINUE;
     }
     _applyCollected(data) {
         try {
@@ -1096,6 +1086,7 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
     }
     destroy() {
         this._destroyed = true;
+        this.extension._Ticks.unregister(this);
         this.extension._Schema.disconnectObject(this);
         if (this.chart)
             this.chart.destroy();
@@ -1103,10 +1094,6 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         if (this._initialUpdateId) {
             GLib.Source.remove(this._initialUpdateId);
             this._initialUpdateId = null;
-        }
-        if (this.timeout) {
-            GLib.Source.remove(this.timeout);
-            this.timeout = null;
         }
         if (this.graph_scale_cooldown_timer_id) {
             GLib.Source.remove(this.graph_scale_cooldown_timer_id);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -70,6 +70,13 @@ const AGGREGATE_DEVICE = 'all';
 // lines back without letting the menu grow sideways to pay for them.
 const MENU_ENTRY_WIDTH = 280;
 
+// ...but only until height is genuinely the thing running out. Past this many
+// lines an entry takes the width it needs instead, because a menu too tall to
+// show its own "Preferences..." is the fault this is all here to fix, and a
+// wide menu is not. Reached only near M01's 64-device cap, where the panel is
+// long past unusable anyway.
+const MENU_ENTRY_LINES = 6;
+
 // What a device is called when its widget does not say otherwise. Right
 // wherever the id is already the name -- interfaces, block devices, sensor
 // labels, GPU indices -- and 'All' for the total, which is the word the
@@ -189,8 +196,9 @@ function reflow_monitor_entry({grid, cells, columns}) {
     for (const cell of cells)
         widest = Math.max(widest, cell.get_preferred_width(-1)[1]);
     const cell_width = widest > 0 ? widest : 1;
-    const wrap = Math.max(1, Math.min(cells.length,
-        Math.floor(MENU_ENTRY_WIDTH * scale / cell_width)));
+    const fits = Math.floor(MENU_ENTRY_WIDTH * scale / cell_width);
+    const needed = Math.ceil(cells.length / MENU_ENTRY_LINES);
+    const wrap = Math.max(1, Math.min(cells.length, Math.max(fits, needed)));
     if (wrap === columns)
         return wrap;
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -74,20 +74,30 @@ export function change_style() {
     this.chart.actor.visible = style === 'graph' || style === 'both';
 }
 
+// A widget's menu cells belong to the widget for the widget's whole life; the
+// table only ever borrows them, and gives them back before it is torn down.
+// Re-creating them here instead threw away the values every widget had just
+// computed -- _syncMonitors updates each widget before it rebuilds the table --
+// so every synchronously collecting widget showed a blank value until its next
+// tick, which is a whole refresh interval away.
+function release_menu_cells(elts) {
+    for (const widget of elts) {
+        for (const item of widget.menu_items)
+            item.get_parent()?.remove_child(item);
+    }
+}
+
 export function build_menu_info(extension) {
     let elts = extension.__sm.elts;
     let tray_menu = extension.__sm.tray.menu;
 
     let firstItem = tray_menu._getMenuItems()[0];
     let lastChild = firstItem?.actor.get_last_child();
-    if (lastChild) {
-        lastChild.destroy_all_children();
-        for (let elt in elts) {
-            elts[elt].menu_items = elts[elt].create_menu_items();
-        }
-    } else {
+    if (!lastChild) {
         return;
     }
+    release_menu_cells(elts);
+    lastChild.destroy_all_children();
 
     let menu_info_box_table = new St.Widget({
         style: 'padding: 10px 0px 10px 0px; spacing-rows: 10px; spacing-columns: 15px;',
@@ -1101,6 +1111,11 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         this._destroyed = true;
         this.extension._Ticks.unregister(this);
         this.extension._Schema.disconnectObject(this);
+        // The other half of the borrow: a cell whose owner is gone must not sit
+        // in the table showing a value nobody is computing any more.
+        for (const item of this.menu_items)
+            item.destroy();
+        this.menu_items = [];
         if (this.chart)
             this.chart.destroy();
         TipBox.prototype.destroy.call(this);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/common.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/common.js
@@ -207,57 +207,13 @@ function check_sensors_async(sensor_type, callback) {
     });
 }
 
-// Several widgets polling sensors on the same chip would each fork their own
-// `sensors` subprocess every refresh tick. Coalesce concurrent reads and
-// briefly cache the result so one spawn serves all widgets on that chip.
-const CHIP_READ_CACHE_MS = 1000;
-const _chip_reads = new Map();
-
-function _read_chip_async(chip, callback) {
-    let entry = _chip_reads.get(chip);
-    if (entry) {
-        if (entry.pending) {
-            entry.pending.push(callback);
-            return;
-        }
-        if (GLib.get_monotonic_time() / 1000 - entry.time < CHIP_READ_CACHE_MS) {
-            callback(entry.data);
-            return;
-        }
-    }
-    entry = {pending: [callback]};
-    _chip_reads.set(chip, entry);
-    const finish = data => {
-        entry.time = GLib.get_monotonic_time() / 1000;
-        entry.data = data;
-        const callbacks = entry.pending;
-        entry.pending = null;
-        for (const cb of callbacks)
-            cb(data);
-    };
-    try {
-        let proc = new Gio.Subprocess({
-            argv: ['sensors', '-jA', chip],
-            flags: Gio.SubprocessFlags.STDOUT_PIPE,
-        });
-        proc.init(null);
-        proc.communicate_utf8_async(null, null, (p, result) => {
-            try {
-                let [, output] = p.communicate_utf8_finish(result);
-                finish(JSON.parse(output)[chip] ?? null);
-            } catch {
-                finish(null);
-            }
-        });
-    } catch {
-        finish(null);
-    }
-}
-
-function read_sensor_async(sensorInfo, callback) {
+// A sensor named by chip comes out of the shared `sensors -jA` reading, so one
+// spawn serves every widget on the panel however many chips they span. A sensor
+// named by sysfs path is genuinely one file per sensor and is read directly.
+function read_sensor_async(cursor, sensorInfo, callback) {
     if (sensorInfo.chip) {
-        _read_chip_async(sensorInfo.chip, chipData => {
-            let value = chipData?.[sensorInfo.sensorLabel]?.[sensorInfo.rawKey];
+        cursor.sample(reading => {
+            let value = reading?.data?.[sensorInfo.chip]?.[sensorInfo.sensorLabel]?.[sensorInfo.rawKey];
             if (value === undefined) {
                 callback(null);
                 return;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/common.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/common.js
@@ -10,6 +10,41 @@ function parse_bytearray(maybeBA) {
     return decoder.decode(maybeBA);
 }
 
+/**
+ * Does I/O to this block device reach storage attached to this machine?
+ *
+ * The block layer accounts a request at every device it traverses, so
+ * /proc/diskstats records one write on the logical volume, again on the
+ * encrypted device under it, again on the partition, and again on the disk. A
+ * total that wants each write once wants the last of those.
+ *
+ * The kernel answers directly: `device` is the symlink the block layer creates
+ * from a *gendisk* to its parent in the driver model. A partition is not a
+ * gendisk, so no partition has one; a virtual block driver -- device-mapper,
+ * md, loop, nbd, zram -- registers its gendisk with no parent, because there is
+ * no hardware to point at, so no layer above a medium has one either.
+ *
+ * /sys/class/block rather than /sys/block: /sys/block holds whole devices only,
+ * so it would reject partitions by path absence and layers by link absence, two
+ * mechanisms wearing one expression. /sys/class/block holds every row of
+ * /proc/diskstats -- measured, in both directions -- so the one clause does
+ * both rejections for the one reason above.
+ *
+ * Named for the role rather than for the link that answers it, and deliberately
+ * not `edge`, the word the net reading uses for the same shape: an nbd device
+ * IS where disk I/O leaves this machine, and it is exactly what this excludes.
+ *
+ * Measured at 3.06 us per device, and never memoised by name -- `dm-0` is
+ * whichever mapping was created first and `loop3` is whichever snap mounted
+ * third, so a memo would be quietly wrong the moment a name was reused.
+ *
+ * @param {string} device - a /proc/diskstats device name
+ * @returns {boolean}
+ */
+function is_storage_medium(device) {
+    return GLib.file_test(`/sys/class/block/${device}/device`, GLib.FileTest.EXISTS);
+}
+
 function _check_sensors_sysfs_async(sensor_type, callback) {
     const hwmon_path = '/sys/class/hwmon/';
     const hwmon_dir = Gio.file_new_for_path(hwmon_path);
@@ -242,4 +277,4 @@ function read_sensor_async(cursor, sensorInfo, callback) {
     }
 }
 
-export { parse_bytearray, check_sensors_async, read_sensor_async };
+export { parse_bytearray, is_storage_medium, check_sensors_async, read_sensor_async };

--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -33,7 +33,7 @@ import { sm_log } from './utils.js';
 import { migrateSettings } from './migration.js';
 import { parseMonitorConfigs, expandMonitors } from './monitors.js';
 import { color_from_string, smStyleManager, build_menu_info } from './base.js';
-import { smSamplers } from './sampling.js';
+import { smSamplers, smTickClock } from './sampling.js';
 import { smMountsMonitor, Bar, Pie } from './mounts.js';
 import { Battery } from './widgets/battery.js';
 import { Cpu } from './widgets/cpu.js';
@@ -234,6 +234,7 @@ export default class SystemMonitorExtension extends Extension {
 
         this._Style = new smStyleManager(this);
         this._MountsMonitor = new smMountsMonitor(this);
+        this._Ticks = new smTickClock();
         this._Samplers = new smSamplers(this);
 
         this._Background = color_from_string(this._Schema.get_string('background'));
@@ -387,8 +388,13 @@ export default class SystemMonitorExtension extends Extension {
             this._MountsMonitor = null;
         }
 
-        // After every widget is destroyed: a sampler may hold a read started on
-        // behalf of one of them, and nothing may outlive the extension.
+        // After every widget is destroyed: each unregisters its own tick, and a
+        // sampler may hold a read started on behalf of one of them. Nothing here
+        // may outlive the extension.
+        if (this._Ticks) {
+            this._Ticks.destroy();
+            this._Ticks = null;
+        }
         if (this._Samplers) {
             this._Samplers.destroy();
             this._Samplers = null;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -32,7 +32,7 @@ import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 import { sm_log } from './utils.js';
 import { migrateSettings } from './migration.js';
 import { parseMonitorConfigs, expandMonitors } from './monitors.js';
-import { color_from_string, smStyleManager, build_menu_info } from './base.js';
+import { color_from_string, smStyleManager, build_menu_info, reflow_menu_entries } from './base.js';
 import { smSamplers, smTickClock } from './sampling.js';
 import { smMountsMonitor, Bar, Pie } from './mounts.js';
 import { Battery } from './widgets/battery.js';
@@ -258,6 +258,8 @@ export default class SystemMonitorExtension extends Extension {
             pie: new Pie(this),
             bar: new Bar(this),
             elts: [],
+            // Multi-device menu entries, which are re-wrapped on menu open.
+            menu_entries: [],
             widgetMap: new Map(),
         };
         let tray = this.__sm.tray;
@@ -323,6 +325,10 @@ export default class SystemMonitorExtension extends Extension {
             (menu, isOpen) => {
                 if (isOpen) {
                     this.__sm.pie.actor.queue_repaint();
+                    // How many devices fit on a line depends on how wide their
+                    // numbers are, and the numbers are only ever as current as
+                    // they are right now.
+                    reflow_menu_entries(this);
 
                     this.menuTimeout = GLib.timeout_add_seconds(
                         GLib.PRIORITY_DEFAULT,

--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -31,6 +31,7 @@ import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 
 import { sm_log } from './utils.js';
 import { migrateSettings } from './migration.js';
+import { parseMonitorConfigs, expandMonitors } from './monitors.js';
 import { color_from_string, smStyleManager, build_menu_info } from './base.js';
 import { smMountsMonitor, Bar, Pie } from './mounts.js';
 import { Battery } from './widgets/battery.js';
@@ -61,20 +62,6 @@ const WIDGET_CLASSES = {
     freq: Freq,
     prometheus: Prometheus,
 };
-
-function parseMonitorConfigs(strv) {
-    let configs = [];
-    for (const s of strv) {
-        try {
-            let c = JSON.parse(s);
-            if (c && c.uuid && c.type)
-                configs.push(c);
-        } catch (e) {
-            sm_log(`Skipping malformed monitor config: ${e.message}`, 'warn');
-        }
-    }
-    return configs;
-}
 
 function change_usage(extension) {
     let usage = extension._Schema.get_string('disk-usage-style');
@@ -140,13 +127,20 @@ export default class SystemMonitorExtension extends Extension {
         }
     }
 
+    // A widget key addresses nothing the user can find, so every message names
+    // the monitor uuid and the device separately -- both of which they can look
+    // up in their settings and in preferences.
+    _describe(config) {
+        return `monitor ${config.monitorUuid} device "${config.device}" (${config.type})`;
+    }
+
     // One malformed entry in the user-editable monitors key must not take
     // down the whole extension (or abort a sync mid-way), so widget
     // construction failures are contained here and the entry skipped.
     _createWidget(config) {
         const WidgetClass = WIDGET_CLASSES[config.type];
         if (!WidgetClass) {
-            sm_log(`Skipping monitor ${config.uuid}: unknown type "${config.type}"`, 'warn');
+            sm_log(`Skipping ${this._describe(config)}: unknown type "${config.type}"`, 'warn');
             return null;
         }
         try {
@@ -154,14 +148,17 @@ export default class SystemMonitorExtension extends Extension {
             widget._activateTimers();
             return widget;
         } catch (e) {
-            sm_log(`Skipping monitor ${config.uuid} (${config.type}): ${e}`, 'error');
+            sm_log(`Skipping ${this._describe(config)}: ${e}`, 'error');
             return null;
         }
     }
 
     _syncMonitors() {
-        const newConfigs = parseMonitorConfigs(this._Schema.get_strv('monitors'));
-        const oldUUIDs = new Set(this.__sm.elts.map(elt => elt.config.uuid));
+        const newConfigs = expandMonitors(parseMonitorConfigs(this._Schema.get_strv('monitors')));
+        // widgetMap owns widget lifetime -- disable() destroys from it, so the
+        // diff must read from it too. Anything in the map but missing from the
+        // panel list would otherwise never be destroyed.
+        const oldUUIDs = new Set(this.__sm.widgetMap.keys());
         const newUUIDs = new Set(newConfigs.map(c => c.uuid));
 
         // Remove widgets no longer in config
@@ -169,7 +166,7 @@ export default class SystemMonitorExtension extends Extension {
         for (const uuid of removedUUIDs) {
             const widget = this.__sm.widgetMap.get(uuid);
             if (widget) {
-                sm_log(`Removing monitor ${uuid}`);
+                sm_log(`Removing ${this._describe(widget.config)}`);
                 widget.destroy();
                 this.__sm.widgetMap.delete(uuid);
             }
@@ -184,11 +181,11 @@ export default class SystemMonitorExtension extends Extension {
                 try {
                     widget.onSettingsChanged(config);
                 } catch (e) {
-                    sm_log(`Monitor ${config.uuid} (${config.type}) failed to apply new settings: ${e}`, 'error');
+                    sm_log(`Failed to apply new settings to ${this._describe(config)}: ${e}`, 'error');
                 }
                 newEltArray.push(widget);
             } else {
-                sm_log(`Adding new monitor ${config.uuid} (${config.type})`);
+                sm_log(`Adding ${this._describe(config)}`);
                 const newWidget = this._createWidget(config);
                 if (newWidget) {
                     this.__sm.widgetMap.set(config.uuid, newWidget);
@@ -277,7 +274,7 @@ export default class SystemMonitorExtension extends Extension {
         this._box.add_child(this.__sm.icon.actor);
 
         // Create widgets from monitors config
-        const monitorConfigs = parseMonitorConfigs(this._Schema.get_strv('monitors'));
+        const monitorConfigs = expandMonitors(parseMonitorConfigs(this._Schema.get_strv('monitors')));
         for (const config of monitorConfigs) {
             const widget = this._createWidget(config);
             if (widget) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -33,6 +33,7 @@ import { sm_log } from './utils.js';
 import { migrateSettings } from './migration.js';
 import { parseMonitorConfigs, expandMonitors } from './monitors.js';
 import { color_from_string, smStyleManager, build_menu_info } from './base.js';
+import { smSamplers } from './sampling.js';
 import { smMountsMonitor, Bar, Pie } from './mounts.js';
 import { Battery } from './widgets/battery.js';
 import { Cpu } from './widgets/cpu.js';
@@ -233,6 +234,7 @@ export default class SystemMonitorExtension extends Extension {
 
         this._Style = new smStyleManager(this);
         this._MountsMonitor = new smMountsMonitor(this);
+        this._Samplers = new smSamplers(this);
 
         this._Background = color_from_string(this._Schema.get_string('background'));
 
@@ -383,6 +385,13 @@ export default class SystemMonitorExtension extends Extension {
         if (this._MountsMonitor) {
             this._MountsMonitor.stopListening();
             this._MountsMonitor = null;
+        }
+
+        // After every widget is destroyed: a sampler may hold a read started on
+        // behalf of one of them, and nothing may outlive the extension.
+        if (this._Samplers) {
+            this._Samplers.destroy();
+            this._Samplers = null;
         }
 
         if (this._Style) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -14,57 +14,74 @@
 #    Copyright 2017 Fran Glais, David King, indigohedgehog@github.
 ##################################################################################
 
-##################################
-#                                #
-#   Check for GPU memory usage   #
-#                                #
-##################################
+##################################################################################
+#
+#   GPU memory and utilisation, for every GPU this machine can report on.
+#
+#   Adding support for another driver means adding a branch below that prints
+#   the same four fields, one line per GPU, space separated:
+#
+#       <index> <total MiB> <used MiB> <busy %>
+#
+#   For example, a machine with two cards:
+#
+#       0 24564 3120 47
+#       1 24564 88 0
+#
+#   Rules the extension relies on:
+#
+#     * Memory is MiB. Both figures, always.
+#     * Indices start at 0 and are contiguous. They are what the preferences
+#       GPU picker offers, so a gap means an entry the panel cannot fill.
+#     * A driver that exposes no utilisation counter prints 0 for busy. That
+#       is expected, not a hole in your branch.
+#     * Print nothing at all if this machine has no GPU you can read. The
+#       extension says so rather than showing a zero it did not measure.
+#
+#   Takes no arguments: every GPU is reported in one run, so the extension
+#   spawns this once per refresh however many GPU widgets are on the panel.
+#
+##################################################################################
 
 checkcommand()
 {
 	command -v "$1" > /dev/null 2>&1
 }
 
-GPU_INDEX=${1:-0}
+# nvidia-smi reports every GPU in one call, so its own exit status is the
+# probe -- no separate --list-gpus run.
+if out=$(nvidia-smi --query-gpu=index,memory.total,memory.used,utilization.gpu \
+		--format=csv,noheader,nounits 2>/dev/null) && [ -n "$out" ]; then
+	echo "$out" | tr -d ' ' | tr ',' ' '
+	exit 0
+fi
 
-# This will print three lines. The first one is the the total vRAM available,
-# the second one is the used vRAM and the third on is the GPU usage in %.
-if nvidia-smi --list-gpus > /dev/null 2>&1  ; then
-	nvidia-smi -i "$GPU_INDEX" --query-gpu=memory.total,memory.used,utilization.gpu --format=csv,noheader,nounits | while IFS=', ' read -r a b c; do echo "$a"; echo "$b"; echo "$c"; done
+# DRM card numbers do not always start at 0 (the GPU can be card1 with no
+# card0, e.g. alongside an integrated GPU), and cards without vram counters
+# are not reportable at all, so the index is the position among the cards we
+# can actually read.
+amd_found=0
+i=0
+for d in /sys/class/drm/card[0-9] /sys/class/drm/card[0-9][0-9]; do
+	[ -e "$d/device/mem_info_vram_total" ] || continue
+	total=$(cat "$d/device/mem_info_vram_total" 2>/dev/null) || continue
+	used=$(cat "$d/device/mem_info_vram_used" 2>/dev/null) || used=0
+	busy=$(cat "$d/device/gpu_busy_percent" 2>/dev/null) || busy=0
+	echo "$i $((total / 1024 / 1024)) $((used / 1024 / 1024)) $busy"
+	i=$((i + 1))
+	amd_found=1
+done
+[ "$amd_found" -eq 1 ] && exit 0
 
-elif lsmod | grep amdgpu > /dev/null; then
-	# DRM card numbers don't always start at 0 (the GPU can be card1 with
-	# no card0, e.g. alongside an integrated GPU), so map the index to the
-	# Nth card that exposes amdgpu's vram counters.
-	card=""
-	i=0
-	for d in /sys/class/drm/card[0-9] /sys/class/drm/card[0-9][0-9]; do
-		[ -e "$d/device/mem_info_vram_total" ] || continue
-		if [ "$i" -eq "$GPU_INDEX" ]; then
-			card=${d##*/}
-			break
-		fi
-		i=$((i + 1))
-	done
-	[ -n "$card" ] || card="card$GPU_INDEX"
-
-	total=$(cat "/sys/class/drm/$card/device/mem_info_vram_total")
-	echo $((total / 1024 / 1024))
-
-	used=$(cat "/sys/class/drm/$card/device/mem_info_vram_used")
-	echo $((used / 1024 / 1024))
-
-	cat "/sys/class/drm/$card/device/gpu_busy_percent"
-
-elif checkcommand glxinfo; then
+if checkcommand glxinfo; then
 	TOTALVRAM=$(glxinfo | grep -A2 -i GL_NVX_gpu_memory_info | grep -E -i 'dedicated')
 	TOTALVRAM=${TOTALVRAM##*:[[:blank:]]}
 	TOTALVRAM=${TOTALVRAM%%[[:blank:]]MB*}
 	AVAILVRAM=$(glxinfo | grep -A4 -i GL_NVX_gpu_memory_info | grep -E -i 'available dedicated')
 	AVAILVRAM=${AVAILVRAM##*:[[:blank:]]}
 	AVAILVRAM=${AVAILVRAM%%[[:blank:]]MB*}
-	FREEVRAM=$((TOTALVRAM - AVAILVRAM))
-	echo "$TOTALVRAM"
-	echo "$FREEVRAM"
-
+	if [ -n "$TOTALVRAM" ] && [ -n "$AVAILVRAM" ]; then
+		# glxinfo reports no utilisation counter.
+		echo "0 $TOTALVRAM $((TOTALVRAM - AVAILVRAM)) 0"
+	fi
 fi

--- a/system-monitor-next@paradoxxx.zero.gmail.com/migration.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/migration.js
@@ -5,7 +5,7 @@ import { sm_log } from './utils.js';
 
 function migrateSettings(extension) {
     const SCHEMA_VERSION_KEY = 'settings-schema-version';
-    const CURRENT_SCHEMA_VERSION = 2;
+    const CURRENT_SCHEMA_VERSION = 3;
 
     const settings = extension.getSettings();
     let currentVersion = settings.get_int(SCHEMA_VERSION_KEY);
@@ -24,6 +24,11 @@ function migrateSettings(extension) {
     if (currentVersion < 2) {
         migrateFrom1(extension, settings);
         currentVersion = 2;
+    }
+
+    if (currentVersion < 3) {
+        migrateFrom2(extension, settings);
+        currentVersion = 3;
     }
 
     settings.set_int(SCHEMA_VERSION_KEY, CURRENT_SCHEMA_VERSION);
@@ -132,6 +137,97 @@ function migrateFrom1(extension, settings) {
 
     settings.set_strv('monitors', monitors);
     sm_log(`Successfully migrated ${monitors.length} monitors to new config format.`);
+}
+
+// Sorts object keys at every level so two configs holding the same settings
+// compare equal regardless of the order their fields were written in. Plain
+// JSON.stringify would compare serialization, and hand-authored configs are a
+// supported input.
+function canonical(value) {
+    if (Array.isArray(value))
+        return value.map(canonical);
+    if (value && typeof value === 'object') {
+        const sorted = {};
+        for (const key of Object.keys(value).sort())
+            sorted[key] = canonical(value[key]);
+        return sorted;
+    }
+    return value;
+}
+
+// Everything that must match for two monitors to be the same monitor watching
+// a different device. `type` is included, so an equal fingerprint already
+// implies an equal type.
+function settingsFingerprint(config) {
+    const settings = {...config};
+    delete settings.uuid;
+    delete settings.device;
+    return JSON.stringify(canonical(settings));
+}
+
+function toDeviceEntry(config) {
+    const entry = {id: config.device};
+    // show-text is per-device from v3 on: a widget's label belongs to the
+    // widget, and one monitor now produces several.
+    if ('show-text' in config)
+        entry['show-text'] = config['show-text'];
+    return entry;
+}
+
+function migrateFrom2(_extension, settings) {
+    sm_log('Migrating settings: v2 -> v3 (monitor device becomes a device set)');
+
+    const raw = settings.get_strv('monitors');
+    const parsed = [];
+    for (const s of raw) {
+        try {
+            const config = JSON.parse(s);
+            if (config && config.uuid && config.type)
+                parsed.push(config);
+            else
+                sm_log('Passing over a monitor with no uuid and type during v2 -> v3 migration', 'warn');
+        } catch (e) {
+            sm_log(`Passing over a malformed monitor during v2 -> v3 migration: ${e.message}`, 'warn');
+        }
+    }
+
+    // A user who had individual CPU cores enabled before the v1 -> v2 migration
+    // owns one monitor per core. Merge a run of adjacent monitors that differ
+    // only in uuid and device back into one entry -- that split is the very
+    // thing a device set exists to undo. Adjacency matters: same-type monitors
+    // placed apart in the list were placed apart deliberately.
+    const runs = [];
+    for (const config of parsed) {
+        // Nothing to convert and nothing to guess: pass it through untouched so
+        // the user still has it to fix, and let it break the run.
+        if (typeof config.device !== 'string' || Array.isArray(config.devices)) {
+            runs.push({config, fingerprint: null, merged: 0});
+            continue;
+        }
+
+        const fingerprint = settingsFingerprint(config);
+        const previous = runs[runs.length - 1];
+        if (previous && previous.fingerprint === fingerprint) {
+            previous.config.devices.push(toDeviceEntry(config));
+            previous.merged++;
+            continue;
+        }
+
+        const converted = {...config, devices: [toDeviceEntry(config)]};
+        delete converted.device;
+        delete converted['show-text'];
+        runs.push({config: converted, fingerprint, merged: 0});
+    }
+
+    for (const run of runs) {
+        if (run.merged > 0) {
+            sm_log(`Merged ${run.merged + 1} adjacent ${run.config.type} monitors into 1 with ` +
+                   `${run.config.devices.length} devices`);
+        }
+    }
+
+    settings.set_strv('monitors', runs.map(run => JSON.stringify(run.config)));
+    sm_log(`Migrated ${parsed.length} monitors to ${runs.length} device sets`);
 }
 
 export { migrateSettings };

--- a/system-monitor-next@paradoxxx.zero.gmail.com/monitors.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/monitors.js
@@ -1,0 +1,162 @@
+/* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+// system-monitor: Gnome shell extension displaying system informations in gnome shell status bar, such as memory usage, cpu usage, network rates…
+// Copyright (C) 2011 Florian Mounier aka paradoxxxzero
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// A monitor is a set of devices, and most sets have one member. This module is
+// the only place either shape is built: parseMonitorConfigs turns the loose
+// `monitors` setting into configs the rest of the extension can trust, and
+// expandMonitor turns one config into one derived config per selected device.
+
+import { sm_log } from './utils.js';
+
+// A monitor covering more devices than this is a corrupt or hand-mangled
+// config; expanding it would spawn that many Cairo charts in the panel.
+const MAX_DEVICES_PER_MONITOR = 64;
+
+// A device entry may not restate what the monitor owns. `type` is the dangerous
+// one: without this, an entry could build a Gpu widget inside a cpu monitor.
+const RESERVED_ENTRY_KEYS = ['type', 'uuid', 'devices', 'device'];
+
+// Injective on (uuid, deviceId) for arbitrary strings, so two devices can never
+// collide onto one widget -- device ids are free text (sensor labels) and a
+// separator-joined key would need a character ban to stay unique. Only ever
+// joined, never split: both halves ride on the derived config as `monitorUuid`
+// and `device`.
+function widget_key(monitorUuid, deviceId) {
+    return JSON.stringify([monitorUuid, deviceId]);
+}
+
+function normalize_entries(raw, label) {
+    let list = raw.devices;
+    if (list === undefined && typeof raw.device === 'string') {
+        list = [raw.device];
+    }
+    if (!Array.isArray(list) || list.length === 0) {
+        sm_log(`${label}: no devices listed - expected "devices": ["all"]. Skipping; it will not appear in the panel.`, 'warn');
+        return null;
+    }
+
+    const entries = [];
+    const seen = new Set();
+    for (const item of list) {
+        const source = typeof item === 'string' ? {id: item} : item;
+        if (!source || typeof source.id !== 'string') {
+            sm_log(`${label}: device entry without an id, ignoring it.`, 'warn');
+            continue;
+        }
+        if (seen.has(source.id)) {
+            sm_log(`${label}: device "${source.id}" listed twice, keeping the first.`, 'warn');
+            continue;
+        }
+        seen.add(source.id);
+
+        const {id, ...override} = source;
+        for (const key of RESERVED_ENTRY_KEYS) {
+            if (key in override) {
+                sm_log(`${label}: device "${id}" tries to override "${key}", which the monitor owns. Ignoring it.`, 'warn');
+                delete override[key];
+            }
+        }
+        entries.push({id, ...override});
+
+        if (entries.length === MAX_DEVICES_PER_MONITOR) {
+            if (list.length > MAX_DEVICES_PER_MONITOR) {
+                sm_log(`${label}: ${list.length} devices listed, keeping the first ${MAX_DEVICES_PER_MONITOR}. ` +
+                       'Split this into two monitors if you need more.', 'warn');
+            }
+            break;
+        }
+    }
+
+    if (entries.length === 0) {
+        sm_log(`${label}: no usable devices. Skipping; it will not appear in the panel.`, 'warn');
+        return null;
+    }
+    return entries;
+}
+
+// Parse the `monitors` strv into canonical configs. Malformed entries are
+// skipped with a warning, never silently repaired: the settings key is
+// user-editable and a monitor quietly doing nothing reads as a bug.
+function parseMonitorConfigs(strv) {
+    const configs = [];
+    const uuids = new Set();
+    let skipped = 0;
+
+    for (const s of strv) {
+        let raw;
+        try {
+            raw = JSON.parse(s);
+        } catch (e) {
+            sm_log(`Skipping malformed monitor config: ${e.message}`, 'warn');
+            skipped++;
+            continue;
+        }
+        if (!raw || typeof raw.uuid !== 'string' || typeof raw.type !== 'string') {
+            sm_log('Skipping a monitor config with no uuid and type.', 'warn');
+            skipped++;
+            continue;
+        }
+
+        const label = `Monitor ${raw.uuid} (${raw.type})`;
+        // Two monitors sharing a uuid expand to the same widget key, which puts
+        // one widget object in the panel list twice and throws when the second
+        // copy is parented.
+        if (uuids.has(raw.uuid)) {
+            sm_log(`${label}: uuid already used by an earlier monitor. Skipping; give it its own uuid.`, 'warn');
+            skipped++;
+            continue;
+        }
+
+        const devices = normalize_entries(raw, label);
+        if (!devices) {
+            skipped++;
+            continue;
+        }
+
+        uuids.add(raw.uuid);
+        const config = {...raw, devices};
+        delete config.device;
+        configs.push(config);
+    }
+
+    if (skipped > 0) {
+        const widgets = configs.reduce((n, c) => n + c.devices.length, 0);
+        sm_log(`Loaded ${configs.length} of ${strv.length} configured monitors (${widgets} panel widgets).`, 'warn');
+    }
+    return configs;
+}
+
+// One config per selected device, in selection order. The entry's remaining
+// keys are a sparse patch over the shared body, so per-device settings beyond
+// show-text cost nothing to add later.
+function expandMonitor(config) {
+    return config.devices.map(({id, ...override}) => {
+        const derived = {...config, ...override};
+        delete derived.devices;
+        derived.device = id;
+        derived.uuid = widget_key(config.uuid, id);
+        derived.monitorUuid = config.uuid;
+        return derived;
+    });
+}
+
+function expandMonitors(configs) {
+    return configs.flatMap(expandMonitor);
+}
+
+export { parseMonitorConfigs, expandMonitor, expandMonitors, MAX_DEVICES_PER_MONITOR };

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -12,6 +12,7 @@ import Adw from "gi://Adw";
 import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
 import { parse_bytearray } from './common.js';
+import { parseMonitorConfigs } from './monitors.js';
 
 const N_ = function (e) {
     return e;
@@ -133,6 +134,26 @@ const SMGeneralPrefsPage = GObject.registerClass({
 
 const MONITOR_TYPES = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'battery', 'freq', 'prometheus'];
 
+// The widget classes carry proper names in their metadata, but importing them
+// here would pull St and the rest of the shell into the preferences process.
+const TYPE_NAMES = {
+    cpu: 'CPU',
+    memory: 'Memory',
+    swap: 'Swap',
+    net: 'Net',
+    disk: 'Disk',
+    gpu: 'GPU',
+    thermal: 'Thermal',
+    fan: 'Fan',
+    battery: 'Battery',
+    freq: 'Frequency',
+    prometheus: 'Prometheus',
+};
+
+function type_name(type) {
+    return TYPE_NAMES[type] || capitalize(type);
+}
+
 const COLOR_MAP = {
     cpu: ['user', 'system', 'nice', 'iowait', 'other'],
     memory: ['program', 'buffer', 'cache'],
@@ -224,6 +245,10 @@ function getDiskDevices() {
     return [];
 }
 
+function gpuName(index) {
+    return _('GPU %d').replace('%d', index.toString());
+}
+
 function getGpuDevices() {
     try {
         let [success, stdout] = GLib.spawn_command_line_sync(
@@ -231,7 +256,7 @@ function getGpuDevices() {
         if (success) {
             let count = parseInt(new TextDecoder().decode(stdout).trim(), 10);
             if (!isNaN(count) && count > 0)
-                return Array.from({length: count}, (_v, i) => i.toString());
+                return Array.from({length: count}, (_v, i) => ({id: i.toString(), name: gpuName(i)}));
         }
     } catch {
         // nvidia-smi not available
@@ -247,11 +272,14 @@ function getGpuDevices() {
         }
         enumerator.close(null);
         if (count > 0)
-            return Array.from({length: count}, (_v, i) => i.toString());
+            return Array.from({length: count}, (_v, i) => ({id: i.toString(), name: gpuName(i)}));
     } catch {
         // fall through
     }
-    return ['0'];
+    // Detection can fail here while gpu_usage.sh still works, so keep the entry
+    // rather than locking those users out -- but say that it was not found
+    // instead of presenting it as a GPU we saw.
+    return [{id: '0', name: `${gpuName(0)} ${_('(not detected)')}`}];
 }
 
 function detectSensors(sensorType) {
@@ -291,43 +319,65 @@ function detectSensors(sensorType) {
     return Object.keys(sensors);
 }
 
-function detectDevices(type) {
+// A type's device axis is one of two shapes, and which one is a fact about what
+// the widget measures. An aggregate is a fold over the members ("all cores");
+// a member is one element; a singleton is neither, which is why it is its own
+// variant rather than an aggregate over an empty set -- there is nothing to
+// choose, so there is no picker.
+function catalogSet(aggregate, members) {
+    return {kind: 'set', aggregate, members};
+}
+
+function catalogSingleton() {
+    return {kind: 'singleton', device: {id: 'default', name: _('Default')}};
+}
+
+function named(ids) {
+    return ids.map(id => ({id, name: id}));
+}
+
+function detectCatalog(type) {
     switch (type) {
     case 'cpu':
     case 'freq':
-        return ['all', ...getCpuCores()];
-    case 'memory':
-    case 'swap':
-    case 'battery':
-        return ['default'];
+        return catalogSet(
+            {id: 'all', name: _('All cores (total)')},
+            getCpuCores().map((id, i) => ({id, name: _('Core %d').replace('%d', (i + 1).toString())})));
     case 'net':
-        return ['all', ...getNetInterfaces()];
+        return catalogSet({id: 'all', name: _('All interfaces (total)')}, named(getNetInterfaces()));
     case 'disk':
-        return ['all', ...getDiskDevices()];
+        return catalogSet({id: 'all', name: _('All disks (total)')}, named(getDiskDevices()));
     case 'gpu':
-        return getGpuDevices();
+        return catalogSet(null, getGpuDevices());
     case 'thermal':
-        return detectSensors('temp');
+        return catalogSet(null, named(detectSensors('temp')));
     case 'fan':
-        return detectSensors('fan');
-    case 'prometheus':
-        return ['default'];
+        return catalogSet(null, named(detectSensors('fan')));
     default:
-        return ['all'];
+        return catalogSingleton();
     }
 }
 
-function buildDefaultConfig(type, device) {
+// Sixteen graphs at the standing 100px default is 1600px of panel, so the
+// zero-thought path would run off the screen and leave the user to work out
+// which knob fixes it. One device still gives exactly 100.
+function defaultGraphWidth(deviceCount) {
+    return Math.min(100, Math.max(20, Math.round(320 / deviceCount)));
+}
+
+function buildDefaultConfig(type, deviceIds) {
     let config = {
         uuid: GLib.uuid_string_random(),
         type: type,
-        device: device,
+        // A device's label is on when it is the only one and off otherwise:
+        // "CPU1 CPU2 CPU3..." across the panel is nobody's goal at sixteen
+        // cores, and position already says which is which.
+        devices: deviceIds.map(id => ({id, 'show-text': deviceIds.length === 1})),
         display: true,
         style: 'graph',
-        'graph-width': 100,
+        'graph-width': defaultGraphWidth(deviceIds.length),
         'refresh-time': type === 'cpu' || type === 'freq' ? 1500 : 5000,
-        'show-text': true,
-        'show-menu': true,
+        'show-menu': deviceIds.length === 1,
         colors: {...(DEFAULT_COLORS[type] || {})},
     };
     if (type === 'thermal') {
@@ -349,6 +399,221 @@ function buildDefaultConfig(type, device) {
     return config;
 }
 
+// ** Device Selection **
+
+function setTriState(check, values) {
+    const on = values.filter(Boolean).length;
+    check.inconsistent = on > 0 && on < values.length;
+    check.active = values.length > 0 && on === values.length;
+}
+
+// Owns which devices a monitor watches and whether each shows its panel label.
+// Builds rows rather than being a widget itself, so the Add dialog can put them
+// in a preferences group and the monitor row can put them in its expander.
+class SMDeviceSelection {
+    constructor(catalog, entries, onChanged) {
+        this._catalog = catalog;
+        this._onChanged = onChanged;
+        this._updating = false;
+        this._rows = [];
+        this._widgets = new Map();
+        this._state = new Map();
+
+        const configured = new Map(entries.map(e => [e.id, e['show-text'] === true]));
+
+        this._devices = [];
+        if (catalog.kind === 'singleton') {
+            this._devices.push(catalog.device);
+        } else {
+            if (catalog.aggregate)
+                this._devices.push({...catalog.aggregate, aggregate: true});
+            this._devices.push(...catalog.members);
+        }
+
+        // A configured device this machine cannot currently see -- a sensor that
+        // vanished, a core on a machine that now has fewer -- has to survive the
+        // round trip, or opening preferences would delete it on the next save.
+        const known = new Set(this._devices.map(d => d.id));
+        for (const id of configured.keys()) {
+            if (!known.has(id))
+                this._devices.push({id, name: `${id} ${_('(not detected)')}`});
+        }
+
+        for (const device of this._devices) {
+            this._state.set(device.id, {
+                selected: catalog.kind === 'singleton' || configured.has(device.id),
+                showText: configured.get(device.id) === true,
+            });
+        }
+
+        this._build();
+    }
+
+    get rows() {
+        return this._rows;
+    }
+
+    get soleDeviceId() {
+        return this._devices.length > 0 ? this._devices[0].id : null;
+    }
+
+    get entries() {
+        return this._devices
+            .filter(d => this._state.get(d.id).selected)
+            .map(d => ({id: d.id, 'show-text': this._state.get(d.id).showText}));
+    }
+
+    get selectedNames() {
+        return this._devices
+            .filter(d => this._state.get(d.id).selected)
+            .map(d => d.name);
+    }
+
+    getShowText(id) {
+        return this._state.get(id)?.showText === true;
+    }
+
+    setShowText(id, value) {
+        const state = this._state.get(id);
+        if (!state || state.showText === value)
+            return;
+        state.showText = value;
+        this._onChanged();
+    }
+
+    _selectedIds() {
+        return this._devices.map(d => d.id).filter(id => this._state.get(id).selected);
+    }
+
+    _build() {
+        if (this._catalog.kind === 'singleton' || this._devices.length === 0)
+            return;
+
+        // Structurally identical to the rows it governs -- same prefix control,
+        // same suffix column -- so what it does needs no explaining. Both halves
+        // are actions rather than stored defaults: nothing in the config records
+        // a "bulk setting", so there is no default-versus-override question.
+        const bulk = new Adw.ActionRow({
+            title: this._catalog.aggregate ? _('All individual devices') : _('All devices'),
+        });
+        this._bulkSelect = new Gtk.CheckButton({valign: Gtk.Align.CENTER});
+        this._bulkSelect.connect('toggled', () => this._onBulkSelect());
+        bulk.add_prefix(this._bulkSelect);
+        this._bulkShowText = new Gtk.CheckButton({label: _('Show text'), valign: Gtk.Align.CENTER});
+        this._bulkShowText.connect('toggled', () => this._onBulkShowText());
+        bulk.add_suffix(this._bulkShowText);
+        this._rows.push(bulk);
+
+        for (const device of this._devices) {
+            const row = new Adw.ActionRow({title: device.name});
+            if (device.aggregate)
+                row.subtitle = _('Combined figure for every device');
+
+            const select = new Gtk.CheckButton({valign: Gtk.Align.CENTER});
+            select.connect('toggled', () => this._onSelect(device.id, select.active));
+            row.add_prefix(select);
+            row.activatable_widget = select;
+
+            const showText = new Gtk.CheckButton({
+                valign: Gtk.Align.CENTER,
+                tooltip_text: _('Show this device\'s text label in the panel'),
+            });
+            showText.connect('toggled', () => this._onShowText(device.id, showText.active));
+            row.add_suffix(showText);
+
+            this._widgets.set(device.id, {select, showText});
+            this._rows.push(row);
+        }
+
+        this._refresh();
+    }
+
+    _onSelect(id, active) {
+        if (this._updating)
+            return;
+        // The last selected device cannot be unticked: a monitor over zero
+        // devices does nothing, and the extension would drop it on load.
+        if (!active && this._selectedIds().length === 1) {
+            this._refresh();
+            return;
+        }
+        const state = this._state.get(id);
+        state.selected = active;
+        if (active)
+            state.showText = this._selectedIds().length === 1;
+        this._refresh();
+        this._onChanged();
+    }
+
+    _onShowText(id, active) {
+        if (this._updating)
+            return;
+        this._state.get(id).showText = active;
+        this._refresh();
+        this._onChanged();
+    }
+
+    // Select governs the individual devices only. An aggregate is the sum over
+    // all of them, so sweeping it in alongside every core would add a redundant
+    // widget that looks like the others and is not.
+    _onBulkSelect() {
+        if (this._updating)
+            return;
+        const target = this._bulkSelect.active;
+        const members = this._devices.filter(d => !d.aggregate);
+        const added = [];
+        for (const device of members) {
+            const state = this._state.get(device.id);
+            if (state.selected === target)
+                continue;
+            state.selected = target;
+            if (target)
+                added.push(device.id);
+        }
+        if (this._selectedIds().length === 0 && members.length > 0) {
+            this._state.get(members[0].id).selected = true;
+            added.push(members[0].id);
+        }
+        const only = this._selectedIds().length === 1;
+        for (const id of added)
+            this._state.get(id).showText = only;
+        this._refresh();
+        this._onChanged();
+    }
+
+    // Show text has no such trap, so it governs every selected device.
+    _onBulkShowText() {
+        if (this._updating)
+            return;
+        const target = this._bulkShowText.active;
+        for (const id of this._selectedIds())
+            this._state.get(id).showText = target;
+        this._refresh();
+        this._onChanged();
+    }
+
+    _refresh() {
+        this._updating = true;
+        const selected = this._selectedIds();
+        for (const device of this._devices) {
+            const state = this._state.get(device.id);
+            const widgets = this._widgets.get(device.id);
+            if (!widgets)
+                continue;
+            widgets.select.active = state.selected;
+            widgets.select.sensitive = !(state.selected && selected.length === 1);
+            widgets.showText.active = state.showText;
+            widgets.showText.sensitive = state.selected;
+        }
+        if (this._bulkSelect) {
+            const members = this._devices.filter(d => !d.aggregate);
+            setTriState(this._bulkSelect, members.map(d => this._state.get(d.id).selected));
+            setTriState(this._bulkShowText, selected.map(id => this._state.get(id).showText));
+        }
+        this._updating = false;
+    }
+}
+
 // ** Monitor Row **
 
 const SMMonitorRow = GObject.registerClass({
@@ -365,8 +630,18 @@ const SMMonitorRow = GObject.registerClass({
         this._colorDialog = new Gtk.ColorDialog({modal: true, with_alpha: true});
         this._dragX = 0;
         this._dragY = 0;
+        this._catalog = detectCatalog(config.type);
+        // An entry inherits any key it does not carry from the shared body, so a
+        // config still holding show-text there (hand-authored, or written before
+        // the device-set migration) must show its real value in the picker.
+        const inherited = config['show-text'] === true;
+        this._selection = new SMDeviceSelection(
+            this._catalog,
+            (config.devices || []).map(e => ({...e, 'show-text': e['show-text'] ?? inherited})),
+            () => this._onSelectionChanged());
 
-        this.title = this._formatTitle();
+        this.title = type_name(config.type);
+        this.subtitle = this._deviceSummary();
 
         let dragHandle = new Gtk.Image({
             icon_name: 'list-drag-handle-symbolic',
@@ -375,8 +650,12 @@ const SMMonitorRow = GObject.registerClass({
         });
         this.add_prefix(dragHandle);
 
+        // GTK throws on an undefined property value where the extension just
+        // reads it as falsy, so a hand-authored config missing a field would
+        // take down the whole preferences window rather than one row. Coerce
+        // to what the extension itself makes of the same value.
         let displaySwitch = new Gtk.Switch({
-            active: config.display,
+            active: config.display === true,
             valign: Gtk.Align.CENTER,
         });
         displaySwitch.connect('notify::active', w => {
@@ -405,12 +684,26 @@ const SMMonitorRow = GObject.registerClass({
         this._buildSettings();
     }
 
-    _formatTitle() {
-        let type = capitalize(this._config.type);
-        let device = this._config.device;
-        if (device === 'default' || device === '')
-            return type;
-        return `${type} — ${device}`;
+    // The names, not a bare count: "5 devices" makes the user expand the row to
+    // find out which five.
+    _deviceSummary() {
+        if (this._catalog.kind === 'singleton')
+            return '';
+        const names = this._selection.selectedNames;
+        const shown = names.slice(0, 3);
+        const rest = names.length - shown.length;
+        if (rest > 0)
+            return `${shown.join(', ')} + ${_('%d more').replace('%d', rest.toString())}`;
+        return shown.join(', ');
+    }
+
+    _onSelectionChanged() {
+        this._config.devices = this._selection.entries;
+        // Every entry now states its own label, so a shared show-text would only
+        // be a second, ignored answer to the same question.
+        delete this._config['show-text'];
+        this.subtitle = this._deviceSummary();
+        this._emitChanged();
     }
 
     _onDragPrepare(_source, x, y) {
@@ -456,20 +749,32 @@ const SMMonitorRow = GObject.registerClass({
     _buildSettings() {
         let c = this._config;
 
-        let showMenu = new Adw.SwitchRow({title: _('Show In Menu'), active: c['show-menu']});
+        for (const row of this._selection.rows)
+            this.add_row(row);
+
+        let showMenu = new Adw.SwitchRow({title: _('Show In Menu'), active: c['show-menu'] === true});
         showMenu.connect('notify::active', w => { c['show-menu'] = w.active; this._emitChanged(); });
         this.add_row(showMenu);
 
-        let showText = new Adw.SwitchRow({title: _('Show Text'), active: c['show-text']});
-        showText.connect('notify::active', w => { c['show-text'] = w.active; this._emitChanged(); });
-        this.add_row(showText);
+        // Every device gets a Show Text control; only its placement varies. With
+        // a picker it rides on the device's row, and a singleton type has no
+        // picker -- so it keeps the standalone switch it has always had.
+        if (this._catalog.kind === 'singleton') {
+            const id = this._selection.soleDeviceId;
+            let showText = new Adw.SwitchRow({
+                title: _('Show Text'),
+                active: this._selection.getShowText(id),
+            });
+            showText.connect('notify::active', w => this._selection.setShowText(id, w.active));
+            this.add_row(showText);
+        }
 
         let styleModel = new Gtk.StringList();
         STYLE_OPTIONS.forEach(s => styleModel.append(_(s)));
         let styleRow = new Adw.ComboRow({
             title: _('Display Style'),
             model: styleModel,
-            selected: STYLE_OPTIONS.indexOf(c.style),
+            selected: Math.max(0, STYLE_OPTIONS.indexOf(c.style)),
         });
         styleRow.connect('notify::selected', w => {
             c.style = STYLE_OPTIONS[w.selected];
@@ -481,11 +786,11 @@ const SMMonitorRow = GObject.registerClass({
             title: _('Graph Width'),
             numeric: true,
             adjustment: new Gtk.Adjustment({
-                value: c['graph-width'], lower: 1, upper: 1000,
+                value: Number(c['graph-width']) || 100, lower: 1, upper: 1000,
                 step_increment: 1, page_increment: 10,
             }),
         });
-        graphWidth.value = c['graph-width'];
+        graphWidth.value = Number(c['graph-width']) || 100;
         this.add_row(graphWidth);
         graphWidth.connect('notify::value', w => {
             c['graph-width'] = w.value;
@@ -497,11 +802,13 @@ const SMMonitorRow = GObject.registerClass({
             subtitle: 'ms',
             numeric: true,
             adjustment: new Gtk.Adjustment({
-                value: c['refresh-time'], lower: 100, upper: 100000,
+                // 1000 matches l_limit() in base.js, which is what the extension
+                // falls back to for a missing or nonsensical interval.
+                value: Number(c['refresh-time']) || 1000, lower: 100, upper: 100000,
                 step_increment: 500, page_increment: 5000,
             }),
         });
-        refreshTime.value = c['refresh-time'];
+        refreshTime.value = Number(c['refresh-time']) || 1000;
         this.add_row(refreshTime);
         refreshTime.connect('notify::value', w => {
             c['refresh-time'] = w.value;
@@ -686,17 +993,9 @@ const SMMonitorsPage = GObject.registerClass({
     }
 
     _loadMonitors() {
-        let strv = this._settings.get_strv('monitors');
-        this._monitors = [];
-        for (const s of strv) {
-            try {
-                let c = JSON.parse(s);
-                if (c && c.uuid && c.type)
-                    this._monitors.push(c);
-            } catch {
-                console.warn('system-monitor-next: skipping malformed monitor config');
-            }
-        }
+        // Same parser the extension uses, so preferences and the panel agree on
+        // what a valid config is and on how a legacy one normalizes.
+        this._monitors = parseMonitorConfigs(this._settings.get_strv('monitors'));
     }
 
     _saveMonitors() {
@@ -736,8 +1035,8 @@ const SMMonitorsPage = GObject.registerClass({
         let dialog = new Adw.Window({
             modal: true,
             title: _('Add Monitor'),
-            default_width: 400,
-            default_height: 280,
+            default_width: 460,
+            default_height: 560,
             transient_for: this.get_root(),
         });
 
@@ -757,41 +1056,61 @@ const SMMonitorsPage = GObject.registerClass({
         box.append(group);
 
         let typeModel = new Gtk.StringList();
-        MONITOR_TYPES.forEach(t => typeModel.append(_(capitalize(t))));
+        MONITOR_TYPES.forEach(t => typeModel.append(_(type_name(t))));
         let typeRow = new Adw.ComboRow({title: _('Type'), model: typeModel});
         group.add(typeRow);
-
-        let deviceModel = new Gtk.StringList();
-        let deviceRow = new Adw.ComboRow({title: _('Device'), model: deviceModel});
-        group.add(deviceRow);
 
         let serverRow = new Adw.EntryRow({title: _('Exporter URL'), text: 'http://localhost:9100'});
         group.add(serverRow);
         let metricRow = new Adw.EntryRow({title: _('Metric (e.g. node_load1 or metric{label="val"})'), text: 'node_load1'});
         group.add(metricRow);
 
-        let currentDevices = [];
+        let deviceGroup = new Adw.PreferencesGroup({
+            title: _('Devices'),
+            description: _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.'),
+        });
+        let scroller = new Gtk.ScrolledWindow({
+            hscrollbar_policy: Gtk.PolicyType.NEVER,
+            vexpand: true,
+            child: deviceGroup,
+        });
+        box.append(scroller);
+
+        let selection = null;
+        let deviceRows = [];
         let addBtn; // created below with the button box
         const updateTypeUI = () => {
             let type = MONITOR_TYPES[typeRow.selected];
             let isPrometheus = type === 'prometheus';
-            deviceRow.visible = !isPrometheus;
             serverRow.visible = isPrometheus;
             metricRow.visible = isPrometheus;
-            let haveDevices = true;
-            if (!isPrometheus) {
-                currentDevices = detectDevices(type);
-                let model = new Gtk.StringList();
-                currentDevices.forEach(d => model.append(d));
-                deviceRow.model = model;
-                deviceRow.selected = 0;
-                // E.g. thermal/fan on a machine with no readable sensors;
-                // a monitor saved without a real device could never
-                // resolve, so block the add instead.
-                haveDevices = currentDevices.length > 0;
-                deviceRow.subtitle = haveDevices ? '' : _('No devices detected');
-            }
-            addBtn.sensitive = haveDevices;
+
+            for (const row of deviceRows)
+                deviceGroup.remove(row);
+            deviceRows = [];
+
+            const catalog = detectCatalog(type);
+            // A singleton type has nothing to choose; the first device is
+            // pre-ticked so the zero-thought path lands on today's behavior.
+            const initial = catalog.kind === 'singleton'
+                ? [catalog.device]
+                : catalog.aggregate ? [catalog.aggregate] : catalog.members.slice(0, 1);
+            selection = new SMDeviceSelection(
+                catalog, initial.map(d => ({id: d.id, 'show-text': true})),
+                () => { addBtn.sensitive = selection.entries.length > 0; });
+
+            deviceRows = selection.rows;
+            for (const row of deviceRows)
+                deviceGroup.add(row);
+            scroller.visible = deviceRows.length > 0;
+
+            // E.g. thermal/fan on a machine with no readable sensors; a monitor
+            // saved without a real device could never resolve, so block the add.
+            const haveDevices = catalog.kind === 'singleton' || deviceRows.length > 0;
+            deviceGroup.description = haveDevices
+                ? _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.')
+                : _('No devices detected');
+            addBtn.sensitive = haveDevices && selection.entries.length > 0;
         };
 
         let btnBox = new Gtk.Box({
@@ -812,8 +1131,11 @@ const SMMonitorsPage = GObject.registerClass({
         });
         addBtn.connect('clicked', () => {
             let type = MONITOR_TYPES[typeRow.selected];
-            let device = currentDevices[deviceRow.selected] || 'all';
-            let config = buildDefaultConfig(type, device);
+            let entries = selection.entries;
+            let config = buildDefaultConfig(type, entries.map(e => e.id));
+            // buildDefaultConfig applies the label default for the count; the
+            // picker may already have been told otherwise.
+            config.devices = entries;
             if (type === 'prometheus') {
                 config.server = serverRow.text || 'http://localhost:9100';
                 config.metric = metricRow.text || 'node_load1';

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -11,7 +11,7 @@ import Adw from "gi://Adw";
 
 import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
-import { parse_bytearray } from './common.js';
+import { parse_bytearray, is_storage_medium } from './common.js';
 import { parseMonitorConfigs } from './monitors.js';
 
 const N_ = function (e) {
@@ -222,22 +222,36 @@ function getNetInterfaces() {
     return [];
 }
 
+// Enumerate from /proc/diskstats, the source the panel reads, so a device the
+// picker offers is a device the panel can show -- the fault M02b fixed for net,
+// where the picker enumerated one way and the widget another. A name regex
+// (sd[a-z]|nvme\d+n\d+|mmcblk\d+|vd[a-z]) stood here, which broke at the 27th
+// SCSI disk and hid every logical volume, encrypted device and zram.
+//
+// Whole devices only. Partitions are dropped because five entries beginning
+// "nvme0n1" make the commonest task in the dialog -- find my disk -- harder for
+// a case nobody has asked for; a config that names a partition still reads it.
+// /sys/block holds exactly the whole devices, so membership is the test.
+//
+// Media first, so the devices the total sums sit directly under it and the ones
+// it excludes sit visibly below, which makes the aggregate's note checkable
+// rather than merely assertable. It also keeps a snap-heavy laptop's thirty
+// loop devices below the disk instead of above it.
 function getDiskDevices() {
     try {
         let file = Gio.File.new_for_path('/proc/diskstats');
         let [success, contents] = file.load_contents(null);
         if (success) {
             let lines = new TextDecoder().decode(contents).split('\n');
-            let disks = new Set();
+            let media = [], layers = [];
             for (let line of lines) {
                 let parts = line.trim().split(/\s+/);
-                if (parts.length > 2) {
-                    let disk = parts[2];
-                    if (disk && /^(sd[a-z]|nvme\d+n\d+|mmcblk\d+|vd[a-z])$/.test(disk))
-                        disks.add(disk);
-                }
+                let disk = parts.length > 2 ? parts[2] : null;
+                if (!disk || !GLib.file_test(`/sys/block/${disk}`, GLib.FileTest.IS_DIR))
+                    continue;
+                (is_storage_medium(disk) ? media : layers).push(disk);
             }
-            return Array.from(disks);
+            return media.concat(layers);
         }
     } catch {
         // fall through
@@ -321,8 +335,10 @@ function detectSensors(sensorType) {
 // choose, so there is no picker.
 //
 // An aggregate may carry a `note`, which replaces the picker's default
-// subtitle. Only net needs one: every other aggregate really is a plain total
-// over the members listed under it, and net's is not.
+// subtitle. Net and disk need one: traffic and block I/O are both layered, so
+// their totals cover the layer where the data reaches hardware rather than
+// every member listed under them. Every other aggregate really is a plain total
+// over its members -- cpu's "all" is every core.
 function catalogSet(aggregate, members) {
     return {kind: 'set', aggregate, members};
 }
@@ -349,7 +365,11 @@ function detectCatalog(type, extensionPath) {
             note: _('Excludes VPN, bridge and container interfaces — their traffic is already counted on the hardware carrying it'),
         }, named(getNetInterfaces()));
     case 'disk':
-        return catalogSet({id: 'all', name: _('All disks (total)')}, named(getDiskDevices()));
+        return catalogSet({
+            id: 'all',
+            name: _('All physical disks (total)'),
+            note: _('Only devices where data reaches a physical disk. Partitions, LVM, RAID and encrypted volumes are excluded — their I/O is counted on the disk underneath'),
+        }, named(getDiskDevices()));
     case 'gpu':
         return catalogSet(null, getGpuDevices(extensionPath));
     case 'thermal':

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -402,9 +402,13 @@ function buildDefaultConfig(type, deviceIds) {
 // ** Device Selection **
 
 // Both hosts of the picker -- the Add dialog and the row's Devices dialog -- say
-// the same thing, because they are the same picker.
-const DEVICE_PICKER_HINT =
-    _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.');
+// the same thing, because they are the same picker. It has to be a function: an
+// extension's gettext resolves which extension is asking from the call stack, so
+// calling it while the module is still being imported throws "gettext can only be
+// called from extensions".
+function devicePickerHint() {
+    return _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.');
+}
 
 function setTriState(check, values) {
     const on = values.filter(Boolean).length;
@@ -751,7 +755,7 @@ const SMMonitorRow = GObject.registerClass({
         });
         toolbar.set_content(box);
 
-        const group = new Adw.PreferencesGroup({description: DEVICE_PICKER_HINT});
+        const group = new Adw.PreferencesGroup({description: devicePickerHint()});
         const rows = this._selection.rows;
         for (const row of rows)
             group.add(row);
@@ -1153,7 +1157,7 @@ const SMMonitorsPage = GObject.registerClass({
 
         let deviceGroup = new Adw.PreferencesGroup({
             title: _('Devices'),
-            description: DEVICE_PICKER_HINT,
+            description: devicePickerHint(),
         });
         let scroller = new Gtk.ScrolledWindow({
             hscrollbar_policy: Gtk.PolicyType.NEVER,
@@ -1193,7 +1197,7 @@ const SMMonitorsPage = GObject.registerClass({
             // E.g. thermal/fan on a machine with no readable sensors; a monitor
             // saved without a real device could never resolve, so block the add.
             const haveDevices = catalog.kind === 'singleton' || deviceRows.length > 0;
-            deviceGroup.description = haveDevices ? DEVICE_PICKER_HINT : _('No devices detected');
+            deviceGroup.description = haveDevices ? devicePickerHint() : _('No devices detected');
             addBtn.sensitive = haveDevices && selection.entries.length > 0;
         };
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -401,6 +401,11 @@ function buildDefaultConfig(type, deviceIds) {
 
 // ** Device Selection **
 
+// Both hosts of the picker -- the Add dialog and the row's Devices dialog -- say
+// the same thing, because they are the same picker.
+const DEVICE_PICKER_HINT =
+    _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.');
+
 function setTriState(check, values) {
     const on = values.filter(Boolean).length;
     check.inconsistent = on > 0 && on < values.length;
@@ -467,6 +472,10 @@ class SMDeviceSelection {
         return this._devices
             .filter(d => this._state.get(d.id).selected)
             .map(d => d.name);
+    }
+
+    get deviceCount() {
+        return this._devices.length;
     }
 
     getShowText(id) {
@@ -703,7 +712,73 @@ const SMMonitorRow = GObject.registerClass({
         // be a second, ignored answer to the same question.
         delete this._config['show-text'];
         this.subtitle = this._deviceSummary();
+        if (this._devicesRow)
+            this._devicesRow.subtitle = this._deviceCount();
         this._emitChanged();
+    }
+
+    _deviceCount() {
+        const total = this._selection.deviceCount;
+        const chosen = this._selection.entries.length;
+        // The total beside the count: "did I get them all?" is the question this
+        // row exists to answer without opening anything.
+        return _('%d of %d selected').replace('%d', chosen.toString()).replace('%d', total.toString());
+    }
+
+    // Choosing devices is a pick-then-done task, and the rarest reason to open
+    // this row -- creating a monitor picks them in the Add dialog, and everything
+    // else here is a setting you nudge. So it gets an entry point rather than the
+    // top third of the row, and the list gets a window of its own instead of
+    // scrolling inside a row inside a page.
+    _openDevicePicker() {
+        const dialog = new Adw.Window({
+            modal: true,
+            title: _('Devices'),
+            default_width: 460,
+            default_height: 620,
+            transient_for: this.get_root(),
+        });
+
+        const toolbar = new Adw.ToolbarView();
+        toolbar.add_top_bar(new Adw.HeaderBar());
+        dialog.set_content(toolbar);
+
+        const box = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            spacing: 12,
+            margin_top: 12, margin_bottom: 12,
+            margin_start: 12, margin_end: 12,
+        });
+        toolbar.set_content(box);
+
+        const group = new Adw.PreferencesGroup({description: DEVICE_PICKER_HINT});
+        const rows = this._selection.rows;
+        for (const row of rows)
+            group.add(row);
+        box.append(new Gtk.ScrolledWindow({
+            hscrollbar_policy: Gtk.PolicyType.NEVER,
+            vexpand: true,
+            child: group,
+        }));
+
+        // Changes apply immediately here as everywhere else on this page -- a
+        // ticked device appears in the panel at once -- so there is nothing to
+        // cancel, only a way out.
+        const buttons = new Gtk.Box({halign: Gtk.Align.END});
+        const close = new Gtk.Button({label: _('Close'), css_classes: ['suggested-action']});
+        close.connect('clicked', () => dialog.close());
+        buttons.append(close);
+        box.append(buttons);
+
+        // The selection outlives the dialog, so hand its rows back before the
+        // group is destroyed or they could not be shown a second time.
+        dialog.connect('close-request', () => {
+            for (const row of rows)
+                group.remove(row);
+            return false;
+        });
+
+        dialog.present();
     }
 
     _onDragPrepare(_source, x, y) {
@@ -749,8 +824,19 @@ const SMMonitorRow = GObject.registerClass({
     _buildSettings() {
         let c = this._config;
 
-        for (const row of this._selection.rows)
-            this.add_row(row);
+        if (this._catalog.kind !== 'singleton') {
+            this._devicesRow = new Adw.ActionRow({
+                title: _('Devices'),
+                subtitle: this._deviceCount(),
+                activatable: true,
+            });
+            this._devicesRow.add_suffix(new Gtk.Image({
+                icon_name: 'go-next-symbolic',
+                valign: Gtk.Align.CENTER,
+            }));
+            this._devicesRow.connect('activated', () => this._openDevicePicker());
+            this.add_row(this._devicesRow);
+        }
 
         let showMenu = new Adw.SwitchRow({title: _('Show In Menu'), active: c['show-menu'] === true});
         showMenu.connect('notify::active', w => { c['show-menu'] = w.active; this._emitChanged(); });
@@ -1067,7 +1153,7 @@ const SMMonitorsPage = GObject.registerClass({
 
         let deviceGroup = new Adw.PreferencesGroup({
             title: _('Devices'),
-            description: _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.'),
+            description: DEVICE_PICKER_HINT,
         });
         let scroller = new Gtk.ScrolledWindow({
             hscrollbar_policy: Gtk.PolicyType.NEVER,
@@ -1107,9 +1193,7 @@ const SMMonitorsPage = GObject.registerClass({
             // E.g. thermal/fan on a machine with no readable sensors; a monitor
             // saved without a real device could never resolve, so block the add.
             const haveDevices = catalog.kind === 'singleton' || deviceRows.length > 0;
-            deviceGroup.description = haveDevices
-                ? _('Tick a device to monitor it. The check on the right shows that device\'s text label in the panel.')
-                : _('No devices detected');
+            deviceGroup.description = haveDevices ? DEVICE_PICKER_HINT : _('No devices detected');
             addBtn.sensitive = haveDevices && selection.entries.length > 0;
         };
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -380,7 +380,7 @@ function buildDefaultConfig(type, deviceIds) {
         style: 'graph',
         'graph-width': defaultGraphWidth(deviceIds.length),
         'refresh-time': type === 'cpu' || type === 'freq' ? 1500 : 5000,
-        'show-menu': deviceIds.length === 1,
+        'show-menu': true,
         colors: {...(DEFAULT_COLORS[type] || {})},
     };
     if (type === 'thermal') {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -319,6 +319,10 @@ function detectSensors(sensorType) {
 // a member is one element; a singleton is neither, which is why it is its own
 // variant rather than an aggregate over an empty set -- there is nothing to
 // choose, so there is no picker.
+//
+// An aggregate may carry a `note`, which replaces the picker's default
+// subtitle. Only net needs one: every other aggregate really is a plain total
+// over the members listed under it, and net's is not.
 function catalogSet(aggregate, members) {
     return {kind: 'set', aggregate, members};
 }
@@ -339,7 +343,11 @@ function detectCatalog(type, extensionPath) {
             {id: 'all', name: _('All cores (total)')},
             getCpuCores().map((id, i) => ({id, name: _('Core %d').replace('%d', (i + 1).toString())})));
     case 'net':
-        return catalogSet({id: 'all', name: _('All interfaces (total)')}, named(getNetInterfaces()));
+        return catalogSet({
+            id: 'all',
+            name: _('All physical interfaces (total)'),
+            note: _('Excludes VPN, bridge and container interfaces — their traffic is already counted on the hardware carrying it'),
+        }, named(getNetInterfaces()));
     case 'disk':
         return catalogSet({id: 'all', name: _('All disks (total)')}, named(getDiskDevices()));
     case 'gpu':
@@ -515,7 +523,7 @@ class SMDeviceSelection {
         for (const device of this._devices) {
             const row = new Adw.ActionRow({title: device.name});
             if (device.aggregate)
-                row.subtitle = _('Combined figure for every device');
+                row.subtitle = device.note || _('Combined figure for every device');
 
             const select = new Gtk.CheckButton({valign: Gtk.Align.CENTER});
             select.connect('toggled', () => this._onSelect(device.id, select.active));

--- a/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/prefs.js
@@ -249,36 +249,31 @@ function gpuName(index) {
     return _('GPU %d').replace('%d', index.toString());
 }
 
-function getGpuDevices() {
+// Enumerate by running the script the panel reads, so a GPU the picker offers
+// is a GPU the panel can show. Counting DRM cards here instead used to disagree
+// with the script on any hybrid-graphics machine -- an Intel card0 with no vram
+// counters and an AMD card1 with them yielded two entries that both resolved to
+// the AMD.
+function getGpuDevices(extensionPath) {
     try {
-        let [success, stdout] = GLib.spawn_command_line_sync(
-            'nvidia-smi --query-gpu=count --format=csv,noheader');
-        if (success) {
-            let count = parseInt(new TextDecoder().decode(stdout).trim(), 10);
-            if (!isNaN(count) && count > 0)
-                return Array.from({length: count}, (_v, i) => ({id: i.toString(), name: gpuName(i)}));
+        if (extensionPath) {
+            let [success, stdout] = GLib.spawn_command_line_sync(
+                `/usr/bin/env bash ${extensionPath}/gpu_usage.sh`);
+            if (success) {
+                const ids = new TextDecoder().decode(stdout).split('\n')
+                    .map(line => line.trim().split(/\s+/))
+                    .filter(field => field.length >= 4 && !isNaN(parseInt(field[1])))
+                    .map(field => field[0]);
+                if (ids.length)
+                    return ids.map(id => ({id, name: gpuName(parseInt(id))}));
+            }
         }
     } catch {
-        // nvidia-smi not available
+        // fall through -- the script may be missing or unreadable
     }
-    try {
-        let drmDir = Gio.File.new_for_path('/sys/class/drm/');
-        let enumerator = drmDir.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
-        let count = 0;
-        let fileInfo;
-        while ((fileInfo = enumerator.next_file(null)) !== null) {
-            if (/^card\d+$/.test(fileInfo.get_name()))
-                count++;
-        }
-        enumerator.close(null);
-        if (count > 0)
-            return Array.from({length: count}, (_v, i) => ({id: i.toString(), name: gpuName(i)}));
-    } catch {
-        // fall through
-    }
-    // Detection can fail here while gpu_usage.sh still works, so keep the entry
-    // rather than locking those users out -- but say that it was not found
-    // instead of presenting it as a GPU we saw.
+    // Detection can fail here while gpu_usage.sh still works on the shell side,
+    // so keep the entry rather than locking those users out -- but say that it
+    // was not found instead of presenting it as a GPU we saw.
     return [{id: '0', name: `${gpuName(0)} ${_('(not detected)')}`}];
 }
 
@@ -336,7 +331,7 @@ function named(ids) {
     return ids.map(id => ({id, name: id}));
 }
 
-function detectCatalog(type) {
+function detectCatalog(type, extensionPath) {
     switch (type) {
     case 'cpu':
     case 'freq':
@@ -348,7 +343,7 @@ function detectCatalog(type) {
     case 'disk':
         return catalogSet({id: 'all', name: _('All disks (total)')}, named(getDiskDevices()));
     case 'gpu':
-        return catalogSet(null, getGpuDevices());
+        return catalogSet(null, getGpuDevices(extensionPath));
     case 'thermal':
         return catalogSet(null, named(detectSensors('temp')));
     case 'fan':
@@ -636,14 +631,15 @@ const SMMonitorRow = GObject.registerClass({
         'delete-requested': {},
     },
 }, class SMMonitorRow extends Adw.ExpanderRow {
-    constructor(config, params = {}) {
+    constructor(config, extensionPath, params = {}) {
         super(params);
 
         this._config = config;
         this._colorDialog = new Gtk.ColorDialog({modal: true, with_alpha: true});
         this._dragX = 0;
         this._dragY = 0;
-        this._catalog = detectCatalog(config.type);
+        this._extensionPath = extensionPath;
+        this._catalog = detectCatalog(config.type, extensionPath);
         // An entry inherits any key it does not carry from the shared body, so a
         // config still holding show-text there (hand-authored, or written before
         // the device-set migration) must show its real value in the picker.
@@ -1037,7 +1033,7 @@ const SMMonitorRow = GObject.registerClass({
 const SMMonitorsPage = GObject.registerClass({
     GTypeName: 'SMMonitorsPage',
 }, class SMMonitorsPage extends Adw.PreferencesPage {
-    constructor(settings, params = {}) {
+    constructor(settings, extensionPath, params = {}) {
         super({
             title: _('Monitors'),
             icon_name: 'utilities-system-monitor-symbolic',
@@ -1045,6 +1041,7 @@ const SMMonitorsPage = GObject.registerClass({
         });
 
         this._settings = settings;
+        this._extensionPath = extensionPath;
         this._monitors = [];
         this._saveTimerId = null;
         this.connect('destroy', () => {
@@ -1111,7 +1108,7 @@ const SMMonitorsPage = GObject.registerClass({
     }
 
     _addRow(config) {
-        let row = new SMMonitorRow(config);
+        let row = new SMMonitorRow(config, this._extensionPath);
         row.connect('config-changed', () => this._saveMonitors());
         row.connect('delete-requested', () => {
             this._listBox.remove(row);
@@ -1179,7 +1176,7 @@ const SMMonitorsPage = GObject.registerClass({
                 deviceGroup.remove(row);
             deviceRows = [];
 
-            const catalog = detectCatalog(type);
+            const catalog = detectCatalog(type, this._extensionPath);
             // A singleton type has nothing to choose; the first device is
             // pre-ticked so the zero-thought path lands on today's behavior.
             const initial = catalog.kind === 'singleton'
@@ -1353,7 +1350,7 @@ export default class SystemMonitorExtensionPreferences extends ExtensionPreferen
         let generalSettingsPage = new SMGeneralPrefsPage(settings);
         window.add(generalSettingsPage);
 
-        let monitorsPage = new SMMonitorsPage(settings);
+        let monitorsPage = new SMMonitorsPage(settings, this.path);
         window.add(monitorsPage);
 
         let whatsNewPage = new SMWhatsNewPage();

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -264,6 +264,45 @@ function readDiskstats(deliver) {
     return () => cancellable.cancel();
 }
 
+// One line per GPU: "<index> <total MiB> <used MiB> <busy %>". See gpu_usage.sh
+// for the contract; parsing it here once serves every GPU widget on the panel.
+function parseGpuUsage(output) {
+    const gpus = new Map();
+    for (const line of output.split('\n')) {
+        const field = line.trim().split(/\s+/);
+        if (field.length < 4)
+            continue;
+        const total = parseInt(field[1]), used = parseInt(field[2]), busy = parseInt(field[3]);
+        if (isNaN(total))
+            continue;
+        gpus.set(field[0], {
+            total,
+            used: isNaN(used) ? 0 : used,
+            busy: isNaN(busy) ? 0 : busy,
+        });
+    }
+    return gpus;
+}
+
+function readGpuUsage(extension) {
+    return deliver => {
+        const proc = new Gio.Subprocess({
+            argv: ['/usr/bin/env', 'bash', `${extension.path}/gpu_usage.sh`],
+            flags: Gio.SubprocessFlags.STDOUT_PIPE,
+        });
+        proc.init(null);
+        proc.communicate_utf8_async(null, null, (p, result) => {
+            try {
+                const [ok, output] = p.communicate_utf8_finish(result);
+                deliver(ok ? parseGpuUsage(output) : null);
+            } catch {
+                deliver(null);
+            }
+        });
+        return () => proc.force_exit();
+    };
+}
+
 // Reading a GTop array field crosses into C and copies the whole array, so a
 // reading touches each one at most once -- and not at all for a monitor that
 // only wants the total, which is what the default configuration asks for.
@@ -339,11 +378,17 @@ export class smSamplers {
         return this._disk;
     }
 
+    get gpu() {
+        this._gpu ??= this._add(new AsyncSampler('gpu', readGpuUsage(this._extension)));
+        return this._gpu;
+    }
+
     destroy() {
         for (const sampler of this._samplers)
             sampler.destroy();
         this._samplers = [];
         this._cpu = null;
         this._disk = null;
+        this._gpu = null;
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -338,10 +338,13 @@ function readDiskstats(deliver) {
                 // A blank line ends the table; anything after it is not a device.
                 if (typeof entry[1] === 'undefined')
                     break;
-                stats.set(entry[2], {
-                    readSectors: parseInt(entry[5]),
-                    writeSectors: parseInt(entry[9]),
-                });
+                const readSectors = parseInt(entry[5]), writeSectors = parseInt(entry[9]);
+                // A row too short to hold both counters is not a device reading
+                // zero, and admitting it as NaN would poison every sum it joins
+                // -- one bad row and the whole aggregate reads NaN, forever.
+                if (isNaN(readSectors) || isNaN(writeSectors))
+                    continue;
+                stats.set(entry[2], {readSectors, writeSectors});
             }
         } catch (e) {
             deliver(null, `could not read /proc/diskstats: ${e.message}`);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -14,10 +14,18 @@
 
 'use strict';
 
+import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import GTop from "gi://GTop";
+import { parse_bytearray } from './common.js';
+import { sm_log } from './utils.js';
 
 let _gen = 0;
+
+// Deliberately shorter than base.js's own 30s guard on collectAsync, so that a
+// wedged read is recovered in one place rather than by two timers racing on
+// whichever happened to be armed first.
+const SAMPLE_TIMEOUT_S = 15;
 
 // The reading that was never taken. A cursor starts at generation 0 and so
 // always forces a first read, which means there is no null case to branch on.
@@ -83,6 +91,177 @@ export class Sampler {
     destroy() {
         this._latest = NEVER;
     }
+}
+
+/**
+ * One widget's position in an asynchronously read source.
+ */
+class AsyncCursor {
+    constructor(sampler) {
+        this._sampler = sampler;
+        this._seen = 0;
+    }
+
+    /**
+     * @param {Function} deliver - called with a reading, or with null if the
+     *   read could not be completed. May be called synchronously.
+     */
+    sample(deliver) {
+        this._sampler.take(this._seen, reading => {
+            if (reading)
+                this._seen = reading.gen;
+            deliver(reading);
+        });
+    }
+}
+
+/**
+ * A shared reading of a source that cannot be read synchronously.
+ *
+ * Callers arriving while a read is in flight join it rather than starting a
+ * second one -- which is what makes sharing work at all for a source whose
+ * read takes longer than the gap between two widgets' ticks.
+ */
+export class AsyncSampler {
+    /**
+     * @param {string} name - source name, used in log messages
+     * @param {Function} read - (deliver) => cancel, where deliver(data) reports
+     *   the result and the returned function, if any, abandons the read
+     */
+    constructor(name, read) {
+        this.name = name;
+        this._read = read;
+        this._latest = NEVER;
+        this._waiting = null;
+        this._watchdog = null;
+        this._cancel = null;
+        this._wedgeLogged = false;
+        this._destroyed = false;
+    }
+
+    cursor() {
+        return new AsyncCursor(this);
+    }
+
+    take(seen, deliver) {
+        if (this._destroyed) {
+            deliver(null);
+            return;
+        }
+        if (this._waiting) {
+            // Joining the read in flight beats taking the older reading: the
+            // one being fetched is fresher.
+            this._waiting.push(deliver);
+            return;
+        }
+        if (this._latest.gen !== seen) {
+            deliver(this._latest);
+            return;
+        }
+
+        this._waiting = [deliver];
+        this._watchdog = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, SAMPLE_TIMEOUT_S, () => {
+            this._watchdog = null;
+            if (!this._wedgeLogged) {
+                sm_log(`${this.name}: read did not complete in ${SAMPLE_TIMEOUT_S}s; abandoned it`, 'warn');
+                this._wedgeLogged = true;
+            }
+            // Killing rather than merely abandoning: a source that hangs would
+            // otherwise leave one orphaned read behind every timeout, forever.
+            this._abandonRead();
+            this._flush(null);
+            return GLib.SOURCE_REMOVE;
+        });
+
+        try {
+            this._cancel = this._read(data => this._complete(data)) || null;
+        } catch (e) {
+            this._complete(null);
+            sm_log(`${this.name}: read failed: ${e}`, 'warn');
+        }
+    }
+
+    _complete(data) {
+        // A late arrival, after the watchdog gave up: it describes an instant
+        // SAMPLE_TIMEOUT_S gone, and the next tick reads fresh anyway.
+        if (this._destroyed || !this._waiting)
+            return;
+        // Recovered means producing readings again, not merely no longer
+        // hanging: a read that keeps completing with nothing has not recovered.
+        if (this._wedgeLogged && data !== null) {
+            sm_log(`${this.name}: reads recovered`);
+            this._wedgeLogged = false;
+        }
+        this._latest = {gen: ++_gen, time: GLib.get_monotonic_time(), data};
+        this._flush(this._latest);
+    }
+
+    // A read that completed with nothing is still a reading, and advances the
+    // generation, so every sibling reports the same failure at the same instant
+    // instead of some riding stale data.
+    _flush(reading) {
+        this._abandonWatchdog();
+        this._cancel = null;
+        const waiting = this._waiting;
+        this._waiting = null;
+        for (const deliver of waiting) {
+            // One subscriber throwing must not strand the rest with their
+            // pending flag stuck set, which would silently stop their updates.
+            try {
+                deliver(reading);
+            } catch (e) {
+                sm_log(`${this.name}: subscriber failed: ${e}`, 'error');
+            }
+        }
+    }
+
+    _abandonWatchdog() {
+        if (this._watchdog) {
+            GLib.Source.remove(this._watchdog);
+            this._watchdog = null;
+        }
+    }
+
+    _abandonRead() {
+        if (this._cancel) {
+            try {
+                this._cancel();
+            } catch (e) {
+                sm_log(`${this.name}: could not abandon the read: ${e}`, 'warn');
+            }
+            this._cancel = null;
+        }
+    }
+
+    destroy() {
+        this._destroyed = true;
+        this._abandonWatchdog();
+        this._abandonRead();
+        this._waiting = null;
+        this._latest = NEVER;
+    }
+}
+
+function readDiskstats(deliver) {
+    const cancellable = new Gio.Cancellable();
+    Gio.File.new_for_path('/proc/diskstats').load_contents_async(cancellable, (file, result) => {
+        let stats = null;
+        try {
+            const [, contents] = file.load_contents_finish(result);
+            stats = new Map();
+            for (const line of parse_bytearray(contents).split('\n')) {
+                const entry = line.trim().split(/[\s]+/);
+                // A blank line ends the table; anything after it is not a device.
+                if (typeof entry[1] === 'undefined')
+                    break;
+                stats.set(entry[2], [parseInt(entry[5]), parseInt(entry[9])]);
+            }
+        } catch {
+            stats = null;
+        }
+        deliver(stats);
+    });
+    return () => cancellable.cancel();
 }
 
 // Reading a GTop array field crosses into C and copies the whole array, so a
@@ -155,10 +334,16 @@ export class smSamplers {
         return this._cpu;
     }
 
+    get disk() {
+        this._disk ??= this._add(new AsyncSampler('disk', readDiskstats));
+        return this._disk;
+    }
+
     destroy() {
         for (const sampler of this._samplers)
             sampler.destroy();
         this._samplers = [];
         this._cpu = null;
+        this._disk = null;
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -18,7 +18,7 @@ import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import GTop from "gi://GTop";
 import Soup from "gi://Soup?version=3.0";
-import { parse_bytearray } from './common.js';
+import { parse_bytearray, is_storage_medium } from './common.js';
 import { sm_log } from './utils.js';
 
 let _gen = 0;
@@ -326,6 +326,14 @@ export class AsyncSampler {
 // The counters are in 512-byte sectors, which is what the kernel publishes
 // whatever the device's own sector size, so the names say so: a consumer that
 // reads `read` cannot tell whether it still owes itself the conversion.
+//
+// `medium` travels with them because a sampler shares the decode, not just the
+// I/O: it is a fact every consumer would otherwise derive identically from the
+// same device list, exactly like the net reading's `edge` and the CPU reading's
+// per-core columns. Classified inside this loop rather than in a second pass,
+// so no reading ever exists with the field unset -- net needs two passes only
+// because its PPP fallback consults a whole-map fact, and disk has no such
+// clause.
 function readDiskstats(deliver) {
     const cancellable = new Gio.Cancellable();
     Gio.File.new_for_path('/proc/diskstats').load_contents_async(cancellable, (file, result) => {
@@ -344,7 +352,10 @@ function readDiskstats(deliver) {
                 // -- one bad row and the whole aggregate reads NaN, forever.
                 if (isNaN(readSectors) || isNaN(writeSectors))
                     continue;
-                stats.set(entry[2], {readSectors, writeSectors});
+                stats.set(entry[2], {
+                    readSectors, writeSectors,
+                    medium: is_storage_medium(entry[2]),
+                });
             }
         } catch (e) {
             deliver(null, `could not read /proc/diskstats: ${e.message}`);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -323,6 +323,9 @@ export class AsyncSampler {
     }
 }
 
+// The counters are in 512-byte sectors, which is what the kernel publishes
+// whatever the device's own sector size, so the names say so: a consumer that
+// reads `read` cannot tell whether it still owes itself the conversion.
 function readDiskstats(deliver) {
     const cancellable = new Gio.Cancellable();
     Gio.File.new_for_path('/proc/diskstats').load_contents_async(cancellable, (file, result) => {
@@ -335,7 +338,10 @@ function readDiskstats(deliver) {
                 // A blank line ends the table; anything after it is not a device.
                 if (typeof entry[1] === 'undefined')
                     break;
-                stats.set(entry[2], [parseInt(entry[5]), parseInt(entry[9])]);
+                stats.set(entry[2], {
+                    readSectors: parseInt(entry[5]),
+                    writeSectors: parseInt(entry[9]),
+                });
             }
         } catch (e) {
             deliver(null, `could not read /proc/diskstats: ${e.message}`);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -264,6 +264,27 @@ function readDiskstats(deliver) {
     return () => cancellable.cancel();
 }
 
+// `sensors -jA` with no chip argument returns every chip -- which is the form
+// common.js already uses to enumerate labels. libsensors reads every chip from
+// sysfs regardless and the chip argument only filters the output, so keying a
+// sampler by chip would spawn once per chip to no purpose.
+function readSensors(deliver) {
+    const proc = new Gio.Subprocess({
+        argv: ['sensors', '-jA'],
+        flags: Gio.SubprocessFlags.STDOUT_PIPE,
+    });
+    proc.init(null);
+    proc.communicate_utf8_async(null, null, (p, result) => {
+        try {
+            const [, output] = p.communicate_utf8_finish(result);
+            deliver(JSON.parse(output));
+        } catch {
+            deliver(null);
+        }
+    });
+    return () => proc.force_exit();
+}
+
 // One line per GPU: "<index> <total MiB> <used MiB> <busy %>". See gpu_usage.sh
 // for the contract; parsing it here once serves every GPU widget on the panel.
 function parseGpuUsage(output) {
@@ -383,6 +404,11 @@ export class smSamplers {
         return this._gpu;
     }
 
+    get sensors() {
+        this._sensors ??= this._add(new AsyncSampler('sensors', readSensors));
+        return this._sensors;
+    }
+
     destroy() {
         for (const sampler of this._samplers)
             sampler.destroy();
@@ -390,5 +416,6 @@ export class smSamplers {
         this._cpu = null;
         this._disk = null;
         this._gpu = null;
+        this._sensors = null;
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -346,6 +346,47 @@ function readDiskstats(deliver) {
     return () => cancellable.cancel();
 }
 
+// /proc/net/dev holds every interface in one table, so this sampler needs no
+// key -- which is what makes it shareable at all. glibtop_get_netload reads one
+// interface per call, so an `all` monitor beside two member monitors made four
+// calls per tick over two interfaces.
+//
+// Column numbers are counted from after the interface's colon. Verified
+// field-for-field against glibtop_get_netload on every interface of a live
+// machine: all five are identical.
+const NET_COLUMNS = [
+    ['bytes_in', 0], ['errors_in', 2],
+    ['bytes_out', 8], ['errors_out', 10], ['collisions', 13],
+];
+
+function readNetDev(deliver) {
+    const cancellable = new Gio.Cancellable();
+    Gio.File.new_for_path('/proc/net/dev').load_contents_async(cancellable, (file, result) => {
+        let interfaces = null;
+        try {
+            const [, contents] = file.load_contents_finish(result);
+            interfaces = new Map();
+            // Two header lines name the columns; every line after them is an
+            // interface, and the colon is what separates its name from them.
+            for (const line of parse_bytearray(contents).split('\n').slice(2)) {
+                const colon = line.indexOf(':');
+                if (colon < 0)
+                    continue;
+                const field = line.slice(colon + 1).trim().split(/\s+/);
+                const counters = {};
+                for (const [key, column] of NET_COLUMNS)
+                    counters[key] = parseInt(field[column]);
+                interfaces.set(line.slice(0, colon).trim(), counters);
+            }
+        } catch (e) {
+            deliver(null, `could not read /proc/net/dev: ${e.message}`);
+            return;
+        }
+        deliver(interfaces);
+    });
+    return () => cancellable.cancel();
+}
+
 // A scrape is the whole exposition -- 100-500 KB for node_exporter -- and every
 // widget on that server greps one line out of the same text. Splitting it is as
 // much of the per-widget cost as fetching it, so the reading carries the split
@@ -528,6 +569,11 @@ export class smSamplers {
         return this._gpu;
     }
 
+    get net() {
+        this._net ??= this._add(new AsyncSampler('net', readNetDev));
+        return this._net;
+    }
+
     get sensors() {
         this._sensors ??= this._add(new AsyncSampler('sensors', readSensors));
         return this._sensors;
@@ -557,6 +603,7 @@ export class smSamplers {
         this._cpu = null;
         this._disk = null;
         this._gpu = null;
+        this._net = null;
         this._sensors = null;
         this._scrapes.clear();
         if (this._session) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -17,6 +17,7 @@
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import GTop from "gi://GTop";
+import Soup from "gi://Soup?version=3.0";
 import { parse_bytearray } from './common.js';
 import { sm_log } from './utils.js';
 
@@ -135,7 +136,7 @@ export class AsyncSampler {
         this._waiting = null;
         this._watchdog = null;
         this._cancel = null;
-        this._wedgeLogged = false;
+        this._faultLogged = false;
         this._destroyed = false;
     }
 
@@ -162,10 +163,7 @@ export class AsyncSampler {
         this._waiting = [deliver];
         this._watchdog = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, SAMPLE_TIMEOUT_S, () => {
             this._watchdog = null;
-            if (!this._wedgeLogged) {
-                sm_log(`${this.name}: read did not complete in ${SAMPLE_TIMEOUT_S}s; abandoned it`, 'warn');
-                this._wedgeLogged = true;
-            }
+            this._reportFault(`read did not complete in ${SAMPLE_TIMEOUT_S}s; abandoned it`);
             // Killing rather than merely abandoning: a source that hangs would
             // otherwise leave one orphaned read behind every timeout, forever.
             this._abandonRead();
@@ -174,26 +172,42 @@ export class AsyncSampler {
         });
 
         try {
-            this._cancel = this._read(data => this._complete(data)) || null;
+            const cancel = this._read((data, reason) => this._complete(data, reason));
+            // A read that delivered synchronously has already flushed and cleared
+            // the handle; storing one now would leave a cancel for a completed
+            // read, to be called on the next timeout or teardown.
+            if (this._waiting)
+                this._cancel = cancel || null;
         } catch (e) {
-            this._complete(null);
-            sm_log(`${this.name}: read failed: ${e}`, 'warn');
+            this._complete(null, `read failed: ${e}`);
         }
     }
 
-    _complete(data) {
+    /**
+     * @param {*} data - the reading, or null if the source produced nothing
+     * @param {string} [reason] - why, when it produced nothing; logged once per
+     *   outage so that a source failing every tick does not fill the journal
+     */
+    _complete(data, reason) {
         // A late arrival, after the watchdog gave up: it describes an instant
         // SAMPLE_TIMEOUT_S gone, and the next tick reads fresh anyway.
         if (this._destroyed || !this._waiting)
             return;
-        // Recovered means producing readings again, not merely no longer
-        // hanging: a read that keeps completing with nothing has not recovered.
-        if (this._wedgeLogged && data !== null) {
+        if (data === null) {
+            this._reportFault(reason || 'read produced nothing');
+        } else if (this._faultLogged) {
             sm_log(`${this.name}: reads recovered`);
-            this._wedgeLogged = false;
+            this._faultLogged = false;
         }
         this._latest = {gen: ++_gen, time: GLib.get_monotonic_time(), data};
         this._flush(this._latest);
+    }
+
+    _reportFault(reason) {
+        if (this._faultLogged)
+            return;
+        this._faultLogged = true;
+        sm_log(`${this.name}: ${reason}`, 'warn');
     }
 
     // A read that completed with nothing is still a reading, and advances the
@@ -256,12 +270,53 @@ function readDiskstats(deliver) {
                     break;
                 stats.set(entry[2], [parseInt(entry[5]), parseInt(entry[9])]);
             }
-        } catch {
-            stats = null;
+        } catch (e) {
+            deliver(null, `could not read /proc/diskstats: ${e.message}`);
+            return;
         }
         deliver(stats);
     });
     return () => cancellable.cancel();
+}
+
+// A scrape is the whole exposition -- 100-500 KB for node_exporter -- and every
+// widget on that server greps one line out of the same text. Splitting it is as
+// much of the per-widget cost as fetching it, so the reading carries the split
+// and does it once, on first use.
+class ScrapeReading {
+    constructor(text) {
+        this.text = text;
+        this._lines = null;
+    }
+
+    lines() {
+        this._lines ??= this.text.split('\n');
+        return this._lines;
+    }
+}
+
+function readScrape(session, server) {
+    return deliver => {
+        const cancellable = new Gio.Cancellable();
+        const message = Soup.Message.new('GET', `${server}/metrics`);
+        if (!message) {
+            deliver(null);
+            return null;
+        }
+        session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, cancellable, (s, result) => {
+            try {
+                const bytes = s.send_and_read_finish(result);
+                if (message.get_status() !== Soup.Status.OK) {
+                    deliver(null, `scrape returned HTTP ${message.get_status()}`);
+                    return;
+                }
+                deliver(new ScrapeReading(new TextDecoder().decode(bytes.get_data())));
+            } catch (e) {
+                deliver(null, `scrape failed: ${e.message}`);
+            }
+        });
+        return () => cancellable.cancel();
+    };
 }
 
 // `sensors -jA` with no chip argument returns every chip -- which is the form
@@ -278,8 +333,8 @@ function readSensors(deliver) {
         try {
             const [, output] = p.communicate_utf8_finish(result);
             deliver(JSON.parse(output));
-        } catch {
-            deliver(null);
+        } catch (e) {
+            deliver(null, `could not read sensor chips: ${e.message}`);
         }
     });
     return () => proc.force_exit();
@@ -315,9 +370,9 @@ function readGpuUsage(extension) {
         proc.communicate_utf8_async(null, null, (p, result) => {
             try {
                 const [ok, output] = p.communicate_utf8_finish(result);
-                deliver(ok ? parseGpuUsage(output) : null);
-            } catch {
-                deliver(null);
+                deliver(ok ? parseGpuUsage(output) : null, 'gpu_usage.sh could not be run');
+            } catch (e) {
+                deliver(null, `gpu_usage.sh failed: ${e.message}`);
             }
         });
         return () => proc.force_exit();
@@ -382,6 +437,8 @@ export class smSamplers {
     constructor(extension) {
         this._extension = extension;
         this._samplers = [];
+        this._scrapes = new Map();
+        this._session = null;
     }
 
     _add(sampler) {
@@ -409,6 +466,23 @@ export class smSamplers {
         return this._sensors;
     }
 
+    /**
+     * Keyed by server: separate endpoints are separate reads, and there is no
+     * call that fetches several at once.
+     * @param {string} server - base URL
+     * @returns {AsyncSampler}
+     */
+    prometheus(server) {
+        let sampler = this._scrapes.get(server);
+        if (!sampler) {
+            this._session ??= new Soup.Session({timeout: 10});
+            sampler = this._add(new AsyncSampler(`prometheus ${server}`,
+                readScrape(this._session, server)));
+            this._scrapes.set(server, sampler);
+        }
+        return sampler;
+    }
+
     destroy() {
         for (const sampler of this._samplers)
             sampler.destroy();
@@ -417,5 +491,10 @@ export class smSamplers {
         this._disk = null;
         this._gpu = null;
         this._sensors = null;
+        this._scrapes.clear();
+        if (this._session) {
+            this._session.abort();
+            this._session = null;
+        }
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -33,6 +33,73 @@ const SAMPLE_TIMEOUT_S = 15;
 const NEVER = {gen: 0, time: 0, data: null};
 
 /**
+ * Widgets that share a refresh interval share a heartbeat.
+ *
+ * One timer per widget, phased by whenever it happened to be constructed, made
+ * sixteen core graphs step at sixteen different moments and drift apart from
+ * there -- the strip ripples instead of moving, and once the phases scatter far
+ * enough a load spike appears on one core's graph and then the next, a
+ * migration that is not in the data.
+ *
+ * Grouping by interval rather than by source is deliberate: sharing a moment is
+ * grouping by refresh interval, sharing a reading is grouping by source, and
+ * two CPU widgets at 500ms and 3000ms must share the source and must not share
+ * the moment.
+ */
+export class smTickClock {
+    constructor() {
+        this._buckets = new Map();
+    }
+
+    /**
+     * @param {object} widget - anything with update(); joins that interval's bucket
+     * @param {number} interval - milliseconds
+     */
+    register(widget, interval) {
+        this.unregister(widget);
+        let bucket = this._buckets.get(interval);
+        if (!bucket) {
+            bucket = {widgets: new Set(), source: 0};
+            bucket.source = GLib.timeout_add(GLib.PRIORITY_DEFAULT_IDLE, interval, () => {
+                // A copy: a widget destroyed by its own update would otherwise
+                // mutate the set being walked.
+                for (const w of [...bucket.widgets]) {
+                    // update() contains its own error handling, but a throw
+                    // escaping here would remove the source and silently stop
+                    // every other widget on this interval, not just this one.
+                    try {
+                        w.update();
+                    } catch (e) {
+                        sm_log(`tick: widget update failed: ${e}`, 'error');
+                    }
+                }
+                return GLib.SOURCE_CONTINUE;
+            });
+            this._buckets.set(interval, bucket);
+        }
+        bucket.widgets.add(widget);
+    }
+
+    unregister(widget) {
+        for (const [interval, bucket] of this._buckets) {
+            if (!bucket.widgets.delete(widget))
+                continue;
+            if (bucket.widgets.size === 0) {
+                GLib.Source.remove(bucket.source);
+                this._buckets.delete(interval);
+            }
+            return;
+        }
+    }
+
+    destroy() {
+        for (const bucket of this._buckets.values())
+            GLib.Source.remove(bucket.source);
+        this._buckets.clear();
+    }
+}
+
+/**
  * One widget's position in one sampler's sequence of readings.
  *
  * The position lives here rather than in the widget so that it cannot advance

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -1,0 +1,164 @@
+/* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
+
+// One read of a shared source, however many widgets consume it.
+//
+// A source is read by whichever widget's timer fires first; every widget that
+// has not yet consumed that reading takes it without a second read. Nothing
+// here owns a refresh timer -- widgets keep their own.
+//
+// The whole correctness argument rests on generations being globally
+// increasing: if a sampler's latest generation differs from the one a cursor
+// last consumed, it is necessarily *newer*, so a free ride is never a repeat.
+// Global rather than per-sampler so that a cursor holding a generation from a
+// sampler that no longer exists still reads correctly.
+
+'use strict';
+
+import GLib from "gi://GLib";
+import GTop from "gi://GTop";
+
+let _gen = 0;
+
+// The reading that was never taken. A cursor starts at generation 0 and so
+// always forces a first read, which means there is no null case to branch on.
+const NEVER = {gen: 0, time: 0, data: null};
+
+/**
+ * One widget's position in one sampler's sequence of readings.
+ *
+ * The position lives here rather than in the widget so that it cannot advance
+ * without a reading being delivered, and cannot be pointed at a second sampler
+ * -- two samplers sharing a token would each make the other look fresh, and
+ * neither would ever be refreshed.
+ */
+class Cursor {
+    constructor(sampler) {
+        this._sampler = sampler;
+        this._seen = 0;
+    }
+
+    /**
+     * @returns {{gen: number, time: number, data: *}}
+     */
+    sample() {
+        const reading = this._sampler.take(this._seen);
+        this._seen = reading.gen;
+        return reading;
+    }
+}
+
+/**
+ * A shared reading of one synchronously readable source.
+ */
+export class Sampler {
+    /**
+     * @param {string} name - source name, used in log messages
+     * @param {Function} read - () => data
+     */
+    constructor(name, read) {
+        this.name = name;
+        this._read = read;
+        this._latest = NEVER;
+    }
+
+    cursor() {
+        return new Cursor(this);
+    }
+
+    /**
+     * @param {number} seen - generation the caller last consumed
+     * @returns {{gen: number, time: number, data: *}} a reading the caller has not consumed
+     */
+    take(seen) {
+        if (this._latest.gen === seen) {
+            // A throw here reaches the widget, which logs it and retries next
+            // tick. The generation deliberately does not advance, so every
+            // sibling retries too rather than riding a stale reading.
+            const data = this._read();
+            this._latest = {gen: ++_gen, time: GLib.get_monotonic_time(), data};
+        }
+        return this._latest;
+    }
+
+    destroy() {
+        this._latest = NEVER;
+    }
+}
+
+// Reading a GTop array field crosses into C and copies the whole array, so a
+// reading touches each one at most once -- and not at all for a monitor that
+// only wants the total, which is what the default configuration asks for.
+const XCPU_FIELDS = {
+    user: 'xcpu_user', system: 'xcpu_sys', nice: 'xcpu_nice',
+    idle: 'xcpu_idle', iowait: 'xcpu_iowait', total: 'xcpu_total',
+};
+
+class CpuReading {
+    constructor(buf) {
+        this._buf = buf;
+        this._cores = null;
+        this.user = buf.user;
+        this.system = buf.sys;
+        this.nice = buf.nice;
+        this.idle = buf.idle;
+        this.iowait = buf.iowait;
+        this.total = buf.total;
+    }
+
+    /**
+     * @param {number} i - core index
+     * @returns {{user, system, nice, idle, iowait, total}} that core's counters
+     */
+    core(i) {
+        if (!this._cores) {
+            this._cores = {};
+            for (const [key, field] of Object.entries(XCPU_FIELDS))
+                this._cores[key] = this._buf[field];
+        }
+        const c = this._cores;
+        return {
+            user: c.user[i], system: c.system[i], nice: c.nice[i],
+            idle: c.idle[i], iowait: c.iowait[i], total: c.total[i],
+        };
+    }
+}
+
+function readCpu() {
+    // A fresh buffer per reading: the lazy core() memo above is only sound
+    // while nothing can refill the struct a reading was built from.
+    const buf = new GTop.glibtop_cpu();
+    GTop.glibtop_get_cpu(buf);
+    return new CpuReading(buf);
+}
+
+/**
+ * Every sampler for one enabled extension.
+ *
+ * Lifetime belongs to the extension rather than the module because GNOME Shell
+ * caches extension modules for the life of the shell process: anything holding
+ * a GLib source or a live session must be torn down with the extension, not
+ * left for a reset call somebody has to remember.
+ */
+export class smSamplers {
+    constructor(extension) {
+        this._extension = extension;
+        this._samplers = [];
+    }
+
+    _add(sampler) {
+        this._samplers.push(sampler);
+        return sampler;
+    }
+
+    get cpu() {
+        this._cpu ??= this._add(new Sampler('cpu', readCpu));
+        return this._cpu;
+    }
+
+    destroy() {
+        for (const sampler of this._samplers)
+            sampler.destroy();
+        this._samplers = [];
+        this._cpu = null;
+    }
+}

--- a/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/sampling.js
@@ -359,6 +359,54 @@ const NET_COLUMNS = [
     ['bytes_out', 8], ['errors_out', 10], ['collisions', 13],
 ];
 
+// ARPHRD_PPP: a PPP link is the machine's edge by definition, and the kernel
+// puts no net device under it -- its hardware is a serial device.
+const ARPHRD_PPP = 512;
+
+// `edge` answers "is this where traffic enters or leaves the machine?", which
+// is the question a total wants: traffic is layered, so a packet sent over a
+// tunnel is counted on the tunnel and again, encapsulated, on the wifi carrying
+// it. The field is named for the role rather than for the test below, because
+// the test already grew a second clause and a field called `hardware` would
+// then misdescribe its own contents.
+//
+// Double-counting is really a property of a *pair* of interfaces, and the
+// kernel publishes only one of the two mechanisms that create such pairs:
+// device stacking (bridge over NIC) appears as `lower_*`/`master` links, while
+// tunnelling is a routing fact with nothing in sysfs tying wg0 to wlp3s0. So no
+// rule over single interfaces can be exact; this is the best available proxy,
+// and it is measured to separate a real NIC from bridge, veth, docker, tun,
+// wireguard, dummy and loopback with no name matching.
+//
+// Classified on every read rather than memoised by name: the test costs 4.6us
+// per interface, so even a 30-interface Docker host pays 137us, and a memo
+// would be quietly wrong when a name is reused by a different kind of device.
+function markEdges(interfaces) {
+    let hardware = false;
+    for (const [name, counters] of interfaces) {
+        counters.edge = GLib.file_test(`/sys/class/net/${name}/device`, GLib.FileTest.EXISTS);
+        hardware ||= counters.edge;
+    }
+    if (hardware)
+        return;
+    // Consulted only when nothing hardware-backed was found, which is what the
+    // clause means -- PPP is an edge precisely because no net device sits under
+    // it -- and also what keeps it cheap: reading `type` costs 8.4us per
+    // interface, and it cannot apply while a hardware interface exists.
+    for (const [name, counters] of interfaces)
+        counters.edge = isPpp(name);
+}
+
+function isPpp(name) {
+    try {
+        const [ok, contents] = GLib.file_get_contents(`/sys/class/net/${name}/type`);
+        return ok && parseInt(parse_bytearray(contents)) === ARPHRD_PPP;
+    } catch {
+        // The interface went away between the two reads.
+        return false;
+    }
+}
+
 function readNetDev(deliver) {
     const cancellable = new Gio.Cancellable();
     Gio.File.new_for_path('/proc/net/dev').load_contents_async(cancellable, (file, result) => {
@@ -378,6 +426,7 @@ function readNetDev(deliver) {
                     counters[key] = parseInt(field[column]);
                 interfaces.set(line.slice(0, colon).trim(), counters);
             }
+            markEdges(interfaces);
         } catch (e) {
             deliver(null, `could not read /proc/net/dev: ${e.message}`);
             return;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor-next-applet.gschema.xml
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor-next-applet.gschema.xml
@@ -540,7 +540,7 @@
     <key name="monitors" type="as">
       <default>[]</default>
       <summary>Monitor widget configurations</summary>
-      <description>JSON array of monitor configurations. Each entry defines a widget instance with type, device, display settings, colors, and refresh rate. Supports multiple instances of the same widget type for multi-device monitoring.</description>
+      <description>JSON array of monitor configurations. Each entry defines a set of devices to monitor, with a shared type, display settings, colors and refresh rate, and expands to one panel widget per device. Individual devices may override any shared setting.</description>
     </key>
   </schema>
 </schemalist>

--- a/system-monitor-next@paradoxxx.zero.gmail.com/stylesheet.css
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/stylesheet.css
@@ -23,6 +23,32 @@
     font-family: monospace;
 }
 
+/* One device inside a monitor's menu entry: its name, then its values, held
+   tight together and well away from the next device. */
+.sm-menu-device {
+    spacing: 3px;
+    padding-right: 16px;
+}
+
+.sm-device-name {
+    opacity: 0.75;
+    font-size: 0.75em;
+    padding-top: 5px;
+    text-align: right;
+}
+
+/* A value takes exactly its own width here, where whole menu rows give it 40px
+   so that rows line up with each other. In a box wider than the number in it a
+   short value sits far from the name in front of it and close to the cell after
+   it, and "1  0 %" beside "2  0 %" reads as "0 %1" -- the next device's name
+   attaching itself to the previous device's value. Cells are held apart by the
+   grid instead, which is where the eye is meant to break. */
+.sm-menu-device .sm-value,
+.sm-menu-device .sm-value-compact {
+    min-width: 0px;
+    padding-right: 3px;
+}
+
 .sm-status-label {
     opacity: 0.75;
     font-size: 0.625em;
@@ -131,6 +157,12 @@
     font-size: 0.5em;
     padding: 2px 0px 0 0px;
 } /* names and Disk R and W signs in text items */
+
+.sm-device-name-compact {
+    opacity: 0.75;
+    font-size: 0.6875em;
+    text-align: right;
+} /* a device's name inside a monitor's menu entry */
 
 .sm-unit-label-compact,
 .sm-net-unit-label-compact {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
@@ -43,6 +43,9 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         this.usage = [0, 0, 0, 1, 0];
 
         if (this.cpuid !== -1) {
+            // Core ids are zero-based and core names are one-based, here and in
+            // the preferences picker.
+            this.device_name = String(this.cpuid + 1);
             this.item_name = _('CPU') + ' ' + (this.cpuid + 1);
             this.label.text = _('CPU') + (this.cpuid + 1);
         } else {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
@@ -2,6 +2,7 @@
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import GTop from "gi://GTop";
+import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
 const Cpu = class SystemMonitor_Cpu extends ElementBase {
@@ -28,6 +29,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         }
 
         this.cursor = extension._Samplers.cpu.cursor();
+        this._missingLogged = false;
         this.last = [0, 0, 0, 0, 0];
         this.current = [0, 0, 0, 0, 0];
         try {
@@ -53,6 +55,19 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         }
 
     }
+
+    // A config can name a core this machine does not have -- carried over from
+    // a machine with more of them, or written by hand. Named the way the menu
+    // and the preferences picker name it, one-based, so that whoever saw "--"
+    // beside a number can look that number up. How many cores there are is what
+    // separates a bad selection from a machine with a core offline.
+    _reportMissing() {
+        if (this._missingLogged)
+            return;
+        this._missingLogged = true;
+        sm_log(`${this.item_name}: this machine has ${this.total_cores} cores. Showing --.`, 'warn');
+    }
+
     collect() {
         const reading = this.cursor.sample();
         // The aggregate divides by the machine's total jiffies, a per-core
@@ -66,8 +81,11 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         // below fires, and the panel shows the value this.usage was initialised
         // with -- a permanent 99%. A core brought online this second reads as no
         // reading for one tick, which is honest.
-        if (!(counters.total > 0))
+        if (!(counters.total > 0)) {
+            this._reportMissing();
             return null;
+        }
+        this._missingLogged = false;
         const scale = this.cpuid === -1 ? 100 * this.total_cores : 100;
 
         this.current[0] = counters.user;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
@@ -27,7 +27,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
             this.cpuid = parseInt(this.device_id);
         }
 
-        this.gtop = new GTop.glibtop_cpu();
+        this.cursor = extension._Samplers.cpu.cursor();
         this.last = [0, 0, 0, 0, 0];
         this.current = [0, 0, 0, 0, 0];
         try {
@@ -51,47 +51,30 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
 
     }
     collect() {
-        GTop.glibtop_get_cpu(this.gtop);
-        if (this.cpuid === -1) {
-            this.current[0] = this.gtop.user;
-            this.current[1] = this.gtop.sys;
-            this.current[2] = this.gtop.nice;
-            this.current[3] = this.gtop.idle;
-            this.current[4] = this.gtop.iowait;
-            let delta = (this.gtop.total - this.last_total) / (100 * this.total_cores);
+        const reading = this.cursor.sample();
+        // The aggregate divides by the machine's total jiffies, a per-core
+        // instance by that core's -- otherwise the same arithmetic.
+        const counters = this.cpuid === -1 ? reading.data : reading.data.core(this.cpuid);
+        const scale = this.cpuid === -1 ? 100 * this.total_cores : 100;
 
-            if (delta > 0) {
-                for (let i = 0; i < 5; i++) {
-                    this.usage[i] = Math.round((this.current[i] - this.last[i]) / delta);
-                    this.last[i] = this.current[i];
-                }
-                this.last_total = this.gtop.total;
-            } else if (delta < 0) {
-                this.last = [0, 0, 0, 0, 0];
-                this.current = [0, 0, 0, 0, 0];
-                this.last_total = 0;
-                this.usage = [0, 0, 0, 1, 0];
-            }
-        } else {
-            this.current[0] = this.gtop.xcpu_user[this.cpuid];
-            this.current[1] = this.gtop.xcpu_sys[this.cpuid];
-            this.current[2] = this.gtop.xcpu_nice[this.cpuid];
-            this.current[3] = this.gtop.xcpu_idle[this.cpuid];
-            this.current[4] = this.gtop.xcpu_iowait[this.cpuid];
-            let delta = (this.gtop.xcpu_total[this.cpuid] - this.last_total) / 100;
+        this.current[0] = counters.user;
+        this.current[1] = counters.system;
+        this.current[2] = counters.nice;
+        this.current[3] = counters.idle;
+        this.current[4] = counters.iowait;
+        let delta = (counters.total - this.last_total) / scale;
 
-            if (delta > 0) {
-                for (let i = 0; i < 5; i++) {
-                    this.usage[i] = Math.round((this.current[i] - this.last[i]) / delta);
-                    this.last[i] = this.current[i];
-                }
-                this.last_total = this.gtop.xcpu_total[this.cpuid];
-            } else if (delta < 0) {
-                this.last = [0, 0, 0, 0, 0];
-                this.current = [0, 0, 0, 0, 0];
-                this.last_total = 0;
-                this.usage = [0, 0, 0, 1, 0];
+        if (delta > 0) {
+            for (let i = 0; i < 5; i++) {
+                this.usage[i] = Math.round((this.current[i] - this.last[i]) / delta);
+                this.last[i] = this.current[i];
             }
+            this.last_total = counters.total;
+        } else if (delta < 0) {
+            this.last = [0, 0, 0, 0, 0];
+            this.current = [0, 0, 0, 0, 0];
+            this.last_total = 0;
+            this.usage = [0, 0, 0, 1, 0];
         }
 
         let percent;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/cpu.js
@@ -58,6 +58,16 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         // The aggregate divides by the machine's total jiffies, a per-core
         // instance by that core's -- otherwise the same arithmetic.
         const counters = this.cpuid === -1 ? reading.data : reading.data.core(this.cpuid);
+        // A core this machine does not have, or one offlined since this widget
+        // was built: GTop's xcpu arrays are a fixed 1024 entries and zero-filled
+        // wherever a core's counters were not read. Jiffies are cumulative since
+        // boot, so any online core has thousands and a zero-filled slot has
+        // none. Without this the delta is exactly 0 on every tick, neither arm
+        // below fires, and the panel shows the value this.usage was initialised
+        // with -- a permanent 99%. A core brought online this second reads as no
+        // reading for one tick, which is honest.
+        if (!(counters.total > 0))
+            return null;
         const scale = this.cpuid === -1 ? 100 * this.total_cores : 100;
 
         this.current[0] = counters.user;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -1,6 +1,7 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
 const Disk = class SystemMonitor_Disk extends ElementBase {
@@ -28,6 +29,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this.cursor = extension._Samplers.disk.cursor();
         this._last = new Map();
         this._lastTime = 0;
+        this._missingLogged = false;
 
         if (this.device_id !== 'all') {
             this.label.text = this.device_id.split('/').pop();
@@ -37,6 +39,18 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
 
     update_mounts(mounts) {
         this.mounts = mounts;
+    }
+
+    // A disk can be selected and then removed, or named in a config carried
+    // over from another machine. The panel can only show "--"; which devices do
+    // exist is the difference between a mystery and a one-line diagnosis, and
+    // it separates a bad selection from a bad machine.
+    _reportMissing(devices) {
+        if (this._missingLogged)
+            return;
+        this._missingLogged = true;
+        sm_log(`${this.item_name}: /proc/diskstats lists ${[...devices.keys()].join(', ')} — ` +
+               `nothing for "${this.device_id}". Showing --.`, 'warn');
     }
 
     destroy() {
@@ -86,9 +100,11 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             // zero. An "all" that matched nothing is: an aggregate is a fold
             // over a set, and the empty set folds to a real zero.
             if (this.device_id !== 'all' && current.size === 0) {
+                this._reportMissing(reading.data);
                 callback(null);
                 return;
             }
+            this._missingLogged = false;
 
             let usage = [0, 0];
             if (delta > 0) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -72,19 +72,29 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
                 totals[0] += counters[0] - prev[0];
                 totals[1] += counters[1] - prev[1];
             }
+            // The counters and the instant they were read at advance together,
+            // or the next tick divides one device set's delta by another's
+            // interval. The reading's own instant, not the clock now: a reading
+            // taken for a faster sibling and consumed here is older than this
+            // tick, and dividing by the wrong interval understates the rate.
+            const time = reading.time / 1000;
+            const delta = (time - this._lastTime) / 1000;
             this._last = current;
+            this._lastTime = time;
 
-            // The reading's own instant, not the clock now: a reading taken for
-            // a faster sibling and consumed here is older than this tick, and
-            // dividing by the wrong interval understates the rate.
-            let time = reading.time / 1000;
-            let delta = (time - this._lastTime) / 1000;
+            // A named device that is not in the table is not a device reading
+            // zero. An "all" that matched nothing is: an aggregate is a fold
+            // over a set, and the empty set folds to a real zero.
+            if (this.device_id !== 'all' && current.size === 0) {
+                callback(null);
+                return;
+            }
+
             let usage = [0, 0];
             if (delta > 0) {
                 for (let i = 0; i < 2; i++)
                     usage[i] = totals[i] / delta / 1024 / 8;
             }
-            this._lastTime = time;
 
             let r = usage[0] < 10 ? Math.round(10 * usage[0]) / 10 : Math.round(usage[0]);
             let w = usage[1] < 10 ? Math.round(10 * usage[1]) / 10 : Math.round(usage[1]);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -1,9 +1,6 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
-import GLib from "gi://GLib";
-import Gio from "gi://Gio";
-import { parse_bytearray } from '../common.js';
 import { ElementBase } from '../base.js';
 
 const Disk = class SystemMonitor_Disk extends ElementBase {
@@ -28,6 +25,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this.mounts = extension._MountsMonitor.get_mounts();
         this._mountListener = this.update_mounts.bind(this);
         extension._MountsMonitor.add_listener(this._mountListener);
+        this.cursor = extension._Samplers.disk.cursor();
         this._last = [0, 0];
         this._lastTime = 0;
 
@@ -47,24 +45,21 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
     }
 
     collectAsync(callback) {
-        let file = Gio.file_new_for_path('/proc/diskstats');
-        file.load_contents_async(null, (source, result) => {
-            if (this._destroyed) { callback(null); return; }
-            let as_r = source.load_contents_finish(result);
-            let lines = parse_bytearray(as_r[1]).toString().split('\n');
+        this.cursor.sample(reading => {
+            if (this._destroyed || !reading?.data) { callback(null); return; }
             let accum = [0, 0];
 
-            for (let i = 0; i < lines.length; i++) {
-                let entry = lines[i].trim().split(/[\s]+/);
-                if (typeof entry[1] === 'undefined')
-                    break;
-                if (this.device_id !== 'all' && !this.device_id.includes(entry[2]))
+            for (const [device, counters] of reading.data) {
+                if (this.device_id !== 'all' && !this.device_id.includes(device))
                     continue;
-                accum[0] += parseInt(entry[5]);
-                accum[1] += parseInt(entry[9]);
+                accum[0] += counters[0];
+                accum[1] += counters[1];
             }
 
-            let time = GLib.get_monotonic_time() / 1000;
+            // The reading's own instant, not the clock now: a reading taken for
+            // a faster sibling and consumed here is older than this tick, and
+            // dividing by the wrong interval understates the rate.
+            let time = reading.time / 1000;
             let delta = (time - this._lastTime) / 1000;
             let usage = [0, 0];
             if (delta > 0) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -33,6 +33,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this._last = new Map();
         this._lastTime = 0;
         this._missingLogged = false;
+        this._noMediumLogged = false;
 
         if (this.device_id !== 'all') {
             this.label.text = this.device_id.split('/').pop();
@@ -52,21 +53,44 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
                `nothing for "${this.device_id}". Showing --.`, 'warn');
     }
 
+    // A total of zero while a disk works is the one way this rule looks broken,
+    // and it happens on a machine whose storage reaches no local hardware -- one
+    // booted from a network block device, say. The picker says what the total
+    // excludes; this is for whoever never opens it, and it names devices that
+    // are both in the message and selectable in the dialog.
+    _reportNoMedium(devices) {
+        if (this._noMediumLogged)
+            return;
+        this._noMediumLogged = true;
+        sm_log(`${this.item_name}: none of ${[...devices.keys()].join(', ')} is a physical ` +
+               'disk — showing 0. To measure one of them, add a monitor for it in ' +
+               'preferences.', 'warn');
+    }
+
+    // An aggregate covers the media; a named monitor covers exactly its row,
+    // medium or not, because naming a device is an explicit request for it.
+    _covers(device, counters) {
+        return this.device_id === 'all' ? counters.medium : device === this.device_id;
+    }
+
     collectAsync(callback) {
         this.cursor.sample(reading => {
             if (this._destroyed || !reading?.data) { callback(null); return; }
 
-            // Invariant: _last maps each device summed at the previous tick to
-            // that device's counters at _lastTime. Every term below is therefore
-            // a difference of two readings OF THE SAME DEVICE, so no term is
-            // negative and neither is the total. A device appearing or
-            // disappearing changes which terms exist, never the sign of one.
+            // Invariant: _last is the previous reading's device table and
+            // _lastTime is the instant it was read at. Every term below is
+            // therefore a difference of two readings OF THE SAME DEVICE, so no
+            // term is negative and neither is the total. Which devices are
+            // covered changes which terms exist, never the sign of one -- and
+            // because _last holds every device rather than only the covered
+            // ones, a device that starts being covered still finds its own
+            // baseline instead of losing a tick.
             const totals = {read: 0, write: 0};
-            const current = new Map();
+            let covered = 0;
             for (const [device, counters] of reading.data) {
-                if (this.device_id !== 'all' && device !== this.device_id)
+                if (!this._covers(device, counters))
                     continue;
-                current.set(device, counters);
+                covered++;
                 const prev = this._last.get(device);
                 // No previous reading means the device has just appeared, and
                 // how much I/O preceded it is not knowable. A counter that went
@@ -88,18 +112,26 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             // tick, and dividing by the wrong interval understates the rate.
             const time = reading.time / 1000;
             const delta = (time - this._lastTime) / 1000;
-            this._last = current;
+            // A delivered reading is never mutated, so the table can be kept
+            // rather than copied.
+            this._last = reading.data;
             this._lastTime = time;
 
             // A named device that is not in the table is not a device reading
             // zero. An "all" that matched nothing is: an aggregate is a fold
             // over a set, and the empty set folds to a real zero.
-            if (this.device_id !== 'all' && current.size === 0) {
-                this._reportMissing(reading.data);
-                callback(null);
-                return;
+            if (covered === 0) {
+                if (this.device_id === 'all') {
+                    this._reportNoMedium(reading.data);
+                } else {
+                    this._reportMissing(reading.data);
+                    callback(null);
+                    return;
+                }
+            } else {
+                this._missingLogged = false;
+                this._noMediumLogged = false;
             }
-            this._missingLogged = false;
 
             const rate = sectors => delta > 0 ? sectors / delta / SECTORS_PER_MIB : 0;
             const read = rate(totals.read), write = rate(totals.write);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -26,7 +26,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this._mountListener = this.update_mounts.bind(this);
         extension._MountsMonitor.add_listener(this._mountListener);
         this.cursor = extension._Samplers.disk.cursor();
-        this._last = [0, 0];
+        this._last = new Map();
         this._lastTime = 0;
 
         if (this.device_id !== 'all') {
@@ -47,14 +47,32 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
     collectAsync(callback) {
         this.cursor.sample(reading => {
             if (this._destroyed || !reading?.data) { callback(null); return; }
-            let accum = [0, 0];
 
+            // Invariant: _last maps each device summed at the previous tick to
+            // that device's counters at _lastTime. Every term below is therefore
+            // a difference of two readings OF THE SAME DEVICE, so no term is
+            // negative and neither is the total. A device appearing or
+            // disappearing changes which terms exist, never the sign of one.
+            let totals = [0, 0];
+            const current = new Map();
             for (const [device, counters] of reading.data) {
                 if (this.device_id !== 'all' && !this.device_id.includes(device))
                     continue;
-                accum[0] += counters[0];
-                accum[1] += counters[1];
+                current.set(device, counters);
+                const prev = this._last.get(device);
+                // No previous reading means the device has just appeared, and
+                // how much I/O preceded it is not knowable. A counter that went
+                // backwards is that same name reused -- a card swapped in the
+                // same reader, a mapper device torn down and recreated -- and
+                // the kernel zeroes the whole stats struct, so either counter
+                // witnesses it. Either way it contributes nothing for one tick
+                // and re-baselines.
+                if (!prev || counters[0] < prev[0] || counters[1] < prev[1])
+                    continue;
+                totals[0] += counters[0] - prev[0];
+                totals[1] += counters[1] - prev[1];
             }
+            this._last = current;
 
             // The reading's own instant, not the clock now: a reading taken for
             // a faster sibling and consumed here is older than this tick, and
@@ -63,10 +81,8 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             let delta = (time - this._lastTime) / 1000;
             let usage = [0, 0];
             if (delta > 0) {
-                for (let i = 0; i < 2; i++) {
-                    usage[i] = (accum[i] - this._last[i]) / delta / 1024 / 8;
-                    this._last[i] = accum[i];
-                }
+                for (let i = 0; i < 2; i++)
+                    usage[i] = totals[i] / delta / 1024 / 8;
             }
             this._lastTime = time;
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -4,6 +4,12 @@ import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.j
 import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
+// /proc/diskstats counts 512-byte sectors, so a MiB is 2048 of them. The panel
+// divided by 1024 and again by 8 and labelled the result MiB/s, which is a
+// quarter of it: measured against dd's own reported throughput, 98.2 shown for
+// a real 392.8 MiB/s.
+const SECTORS_PER_MIB = 2048;
+
 const Disk = class SystemMonitor_Disk extends ElementBase {
     static metadata = {
         name: 'Disk',
@@ -95,7 +101,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             }
             this._missingLogged = false;
 
-            const rate = sectors => delta > 0 ? sectors / delta / 1024 / 8 : 0;
+            const rate = sectors => delta > 0 ? sectors / delta / SECTORS_PER_MIB : 0;
             const read = rate(totals.read), write = rate(totals.write);
 
             let r = read < 10 ? Math.round(10 * read) / 10 : Math.round(read);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -56,7 +56,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             let totals = [0, 0];
             const current = new Map();
             for (const [device, counters] of reading.data) {
-                if (this.device_id !== 'all' && !this.device_id.includes(device))
+                if (this.device_id !== 'all' && device !== this.device_id)
                     continue;
                 current.set(device, counters);
                 const prev = this._last.get(device);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -55,7 +55,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             // a difference of two readings OF THE SAME DEVICE, so no term is
             // negative and neither is the total. A device appearing or
             // disappearing changes which terms exist, never the sign of one.
-            let totals = [0, 0];
+            const totals = {read: 0, write: 0};
             const current = new Map();
             for (const [device, counters] of reading.data) {
                 if (this.device_id !== 'all' && device !== this.device_id)
@@ -69,10 +69,11 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
                 // the kernel zeroes the whole stats struct, so either counter
                 // witnesses it. Either way it contributes nothing for one tick
                 // and re-baselines.
-                if (!prev || counters[0] < prev[0] || counters[1] < prev[1])
+                if (!prev || counters.readSectors < prev.readSectors ||
+                    counters.writeSectors < prev.writeSectors)
                     continue;
-                totals[0] += counters[0] - prev[0];
-                totals[1] += counters[1] - prev[1];
+                totals.read += counters.readSectors - prev.readSectors;
+                totals.write += counters.writeSectors - prev.writeSectors;
             }
             // The counters and the instant they were read at advance together,
             // or the next tick divides one device set's delta by another's
@@ -94,18 +95,15 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             }
             this._missingLogged = false;
 
-            let usage = [0, 0];
-            if (delta > 0) {
-                for (let i = 0; i < 2; i++)
-                    usage[i] = totals[i] / delta / 1024 / 8;
-            }
+            const rate = sectors => delta > 0 ? sectors / delta / 1024 / 8 : 0;
+            const read = rate(totals.read), write = rate(totals.write);
 
-            let r = usage[0] < 10 ? Math.round(10 * usage[0]) / 10 : Math.round(usage[0]);
-            let w = usage[1] < 10 ? Math.round(10 * usage[1]) / 10 : Math.round(usage[1]);
+            let r = read < 10 ? Math.round(10 * read) / 10 : Math.round(read);
+            let w = write < 10 ? Math.round(10 * write) / 10 : Math.round(write);
             const Locale = this.extension._Locale;
             const units = this.extension._Style.diskunits();
             callback({
-                metrics: {read: usage[0], write: usage[1]},
+                metrics: {read, write},
                 display: r.toLocaleString(Locale),
                 display2: w.toLocaleString(Locale),
                 unit: units, unit2: units,

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/disk.js
@@ -23,9 +23,6 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
 
     constructor(extension, config) {
         super(extension, config);
-        this.mounts = extension._MountsMonitor.get_mounts();
-        this._mountListener = this.update_mounts.bind(this);
-        extension._MountsMonitor.add_listener(this._mountListener);
         this.cursor = extension._Samplers.disk.cursor();
         this._last = new Map();
         this._lastTime = 0;
@@ -35,10 +32,6 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             this.label.text = this.device_id.split('/').pop();
             this.item_name = _('Disk') + ' ' + this.device_id;
         }
-    }
-
-    update_mounts(mounts) {
-        this.mounts = mounts;
     }
 
     // A disk can be selected and then removed, or named in a config carried
@@ -51,11 +44,6 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this._missingLogged = true;
         sm_log(`${this.item_name}: /proc/diskstats lists ${[...devices.keys()].join(', ')} — ` +
                `nothing for "${this.device_id}". Showing --.`, 'warn');
-    }
-
-    destroy() {
-        this.extension._MountsMonitor.remove_listener(this._mountListener);
-        super.destroy();
     }
 
     collectAsync(callback) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/fan.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/fan.js
@@ -34,8 +34,26 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
         }
     }
 
+    // Not a bad selection but a machine with nothing to select: no hwmon fan
+    // inputs and no lm_sensors, which is ordinary on a virtual machine. The
+    // panel can only show "--", and without this there is nothing anywhere
+    // saying why.
+    _reportNoSensors() {
+        if (!this._display_error)
+            return;
+        this._display_error = false;
+        sm_log(`${this.item_name}: this machine reports no fan sensors. Showing --. ` +
+               'Installing lm_sensors may expose more of them.', 'warn');
+    }
+
     collectAsync(callback) {
-        if (!this.sensors || Object.keys(this.sensors).length === 0) {
+        if (!this.sensors) {
+            // Enumeration has not come back yet, which is not a fault.
+            callback(null);
+            return;
+        }
+        if (Object.keys(this.sensors).length === 0) {
+            this._reportNoSensors();
             callback(null);
             return;
         }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/fan.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/fan.js
@@ -16,6 +16,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
     constructor(extension, config) {
         super(extension, config);
         this.sensor_label = this.device_id;
+        this.cursor = extension._Samplers.sensors.cursor();
         this.sensors = null;
         check_sensors_async('fan', sensors => {
             this.sensors = sensors;
@@ -48,7 +49,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             callback(null);
             return;
         }
-        read_sensor_async(sensorInfo, value => {
+        read_sensor_async(this.cursor, sensorInfo, value => {
             if (this._destroyed) { callback(null); return; }
             if (value === null) {
                 if (this._display_error) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
@@ -21,7 +21,10 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         super(extension, config);
 
         if (this.device_id !== 'all') {
+            // Core ids are zero-based and core names are one-based, here and in
+            // the preferences picker.
             let coreNum = parseInt(this.device_id) + 1;
+            this.device_name = String(coreNum);
             this.label.text = _('F') + coreNum;
             this.item_name = _('Freq Core ') + coreNum;
         }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/frequency.js
@@ -4,6 +4,7 @@ import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.j
 import Gio from "gi://Gio";
 import GTop from "gi://GTop";
 import { parse_bytearray } from '../common.js';
+import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
 const Freq = class SystemMonitor_Freq extends ElementBase {
@@ -29,7 +30,21 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
             this.item_name = _('Freq Core ') + coreNum;
         }
 
+        this._noFrequencyLogged = false;
     }
+
+    // No cpufreq at all, which is ordinary on a virtual machine and on some
+    // container hosts -- the kernel simply does not publish
+    // scaling_cur_freq. The panel can only show "--", and without this there is
+    // nothing anywhere saying why.
+    _reportNoFrequency() {
+        if (this._noFrequencyLogged)
+            return;
+        this._noFrequencyLogged = true;
+        sm_log(`${this.item_name}: no core published a frequency under ` +
+               '/sys/devices/system/cpu/*/cpufreq. Showing --.', 'warn');
+    }
+
     collectAsync(callback) {
         let display_mode = this.config['display-mode'] || 'max';
         let indices;
@@ -53,9 +68,11 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
             if (this._destroyed) { callback(null); return; }
             if (pos >= indices.length) {
                 if (read_count === 0) {
+                    this._reportNoFrequency();
                     callback(null);
                     return;
                 }
+                this._noFrequencyLogged = false;
                 let freq = display_mode === 'average'
                     ? Math.round(total_frequency / read_count / 1000)
                     : Math.round(max_frequency / 1000);

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
@@ -39,9 +39,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
             const gpu = reading?.data?.get(this.gpu_index);
             if (!gpu) {
                 this._reportMissing(reading?.data);
-                // Charting a 0 for a GPU nobody could read is indistinguishable
-                // from an idle one; say there is no reading instead.
-                callback({display: '--', detail: '', detailUnit: this._unitStr()});
+                callback(null);
                 return;
             }
             this._missingLogged = false;

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/gpu.js
@@ -1,7 +1,7 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
-import Gio from "gi://Gio";
+import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
 const Gpu = class SystemMonitor_Gpu extends ElementBase {
@@ -19,6 +19,8 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
         super(extension, config);
         this.max = 100;
         this.gpu_index = this.device_id;
+        this.cursor = extension._Samplers.gpu.cursor();
+        this._missingLogged = false;
         this._mem = 0;
         this._total = 0;
         this._percentage = 0;
@@ -29,70 +31,70 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
     }
 
     collectAsync(callback) {
-        try {
-            let path = this.extension.path;
-            let script = ['/usr/bin/env', 'bash', path + '/gpu_usage.sh', this.gpu_index];
-            let proc = new Gio.Subprocess({argv: script, flags: Gio.SubprocessFlags.STDOUT_PIPE});
-            proc.init(null);
-            proc.communicate_utf8_async(null, null, (p, result) => {
-                if (this._destroyed) {
-                    callback(null);
-                    return;
-                }
-                let [ok, output] = p.communicate_utf8_finish(result);
-                if (!ok) {
-                    callback(null);
-                    return;
-                }
-                this._parseOutput(output);
-                if (this._total === 0) {
-                    callback({metrics: {used: 0, memory: 0}, display: '0',
-                        detail: '', detailUnit: this._unitStr()});
-                } else {
-                    const Locale = this.extension._Locale;
-                    let memPct = this._mem / this._total * 100 - this._percentage;
-                    let compact = this.extension._Style.get('') === '-compact';
-                    let sep = compact ? '/' : '  /  ';
-                    let unitStr = this._unitStr();
-                    callback({
-                        metrics: {
-                            used: this._percentage,
-                            memory: memPct,
-                        },
-                        display: Math.round(this._percentage).toLocaleString(Locale),
-                        detail: this._pad(this._mem).toLocaleString(Locale) +
-                            sep + this._pad(this._total).toLocaleString(Locale),
-                        detailUnit: unitStr,
-                        tipVals: [this._percentage, this._mem],
-                        tipUnits: ['%', '/ ' + this._total + ' ' + unitStr],
-                    });
-                }
+        this.cursor.sample(reading => {
+            if (this._destroyed) {
+                callback(null);
+                return;
+            }
+            const gpu = reading?.data?.get(this.gpu_index);
+            if (!gpu) {
+                this._reportMissing(reading?.data);
+                // Charting a 0 for a GPU nobody could read is indistinguishable
+                // from an idle one; say there is no reading instead.
+                callback({display: '--', detail: '', detailUnit: this._unitStr()});
+                return;
+            }
+            this._missingLogged = false;
+            this._scaleUnits(gpu);
+
+            const Locale = this.extension._Locale;
+            let memPct = this._mem / this._total * 100 - this._percentage;
+            let compact = this.extension._Style.get('') === '-compact';
+            let sep = compact ? '/' : '  /  ';
+            let unitStr = this._unitStr();
+            callback({
+                metrics: {
+                    used: this._percentage,
+                    memory: memPct,
+                },
+                display: Math.round(this._percentage).toLocaleString(Locale),
+                detail: this._pad(this._mem).toLocaleString(Locale) +
+                    sep + this._pad(this._total).toLocaleString(Locale),
+                detailUnit: unitStr,
+                tipVals: [this._percentage, this._mem],
+                tipUnits: ['%', '/ ' + this._total + ' ' + unitStr],
             });
-        } catch (err) {
-            console.error(err.message);
-            callback(null);
-        }
+        });
     }
 
-    _parseOutput(procOutput) {
-        let usage = procOutput.split('\n');
-        let memTotal = this._parseInt(usage[0]);
-        let memUsed = this._parseInt(usage[1]);
-        this._percentage = this._parseInt(usage[2]);
-        if (typeof this.useGiB === 'undefined')
-            this._initUnit(memTotal);
-        if (this.useGiB) {
-            this._mem = Math.round(memUsed / this._unitConversion) / this._decimals;
-            this._total = Math.round(memTotal / this._unitConversion) / this._decimals;
+    // The panel can only say "no reading"; which GPUs the script did report is
+    // the difference between a mystery and a one-line diagnosis.
+    _reportMissing(gpus) {
+        if (this._missingLogged)
+            return;
+        this._missingLogged = true;
+        const script = `${this.extension.path}/gpu_usage.sh`;
+        const listed = gpus ? [...gpus.keys()] : [];
+        if (listed.length) {
+            sm_log(`${this.item_name}: gpu_usage.sh listed GPUs ${listed.join(', ')} — ` +
+                   `nothing for ${this.gpu_index}. Showing "--".`, 'warn');
         } else {
-            this._mem = Math.round(memUsed / this._unitConversion);
-            this._total = Math.round(memTotal / this._unitConversion);
+            sm_log(`${this.item_name}: gpu_usage.sh listed no GPUs. ` +
+                   `Run it by hand to see why: bash ${script}`, 'warn');
         }
     }
 
-    _parseInt(val) {
-        val = parseInt(val);
-        return isNaN(val) ? 0 : val;
+    _scaleUnits(gpu) {
+        if (typeof this.useGiB === 'undefined')
+            this._initUnit(gpu.total);
+        this._percentage = gpu.busy;
+        if (this.useGiB) {
+            this._mem = Math.round(gpu.used / this._unitConversion) / this._decimals;
+            this._total = Math.round(gpu.total / this._unitConversion) / this._decimals;
+        } else {
+            this._mem = Math.round(gpu.used / this._unitConversion);
+            this._total = Math.round(gpu.total / this._unitConversion);
+        }
     }
 
     _initUnit(total) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
@@ -45,7 +45,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
         }
 
         this.cursor = extension._Samplers.net.cursor();
-        this._last = [0, 0, 0, 0, 0];
+        this._last = new Map();
         this._lastTime = 0;
         this.tip_format([_('KiB/s'), '/s', _('KiB/s'), '/s', '/s']);
         try {
@@ -114,14 +114,32 @@ const Net = class SystemMonitor_Net extends ElementBase {
                 return;
             }
 
-            let accum = [0, 0, 0, 0, 0];
+            // Invariant: _last maps each interface summed at the previous tick
+            // to that interface's counters at _lastTime. Every term below is
+            // therefore a difference of two readings OF THE SAME INTERFACE, so
+            // no term is negative and neither is the total. An interface
+            // appearing or disappearing changes which terms exist, never the
+            // sign of one.
+            let totals = [0, 0, 0, 0, 0];
+            let current = new Map();
             for (const iface of this.ifs) {
-                const counters = reading.data.get(iface);
-                if (!counters)
+                const now = reading.data.get(iface);
+                if (!now)
+                    continue;
+                current.set(iface, now);
+                const prev = this._last.get(iface);
+                // No previous reading means the interface has just appeared,
+                // and how much traffic preceded it is not knowable. A counter
+                // that went backwards is that same interface destroyed and
+                // recreated under its own name -- the kernel zeroes the whole
+                // stats struct, so bytes_in witnesses it for all five. Either
+                // way it contributes nothing for one tick and re-baselines.
+                if (!prev || now.bytes_in < prev.bytes_in)
                     continue;
                 for (let i = 0; i < 5; i++)
-                    accum[i] += counters[FIELDS[i]];
+                    totals[i] += now[FIELDS[i]] - prev[FIELDS[i]];
             }
+            this._last = current;
 
             // The reading's own instant, not the clock now: a reading taken for
             // a faster sibling and consumed here is older than this tick, and
@@ -130,10 +148,8 @@ const Net = class SystemMonitor_Net extends ElementBase {
             let delta = time - this._lastTime;
             let usage = [0, 0, 0, 0, 0];
             if (delta > 0) {
-                for (let i = 0; i < 5; i++) {
-                    usage[i] = Math.round((accum[i] - this._last[i]) / delta);
-                    this._last[i] = accum[i];
-                }
+                for (let i = 0; i < 5; i++)
+                    usage[i] = Math.round(totals[i] / delta);
             }
             this._lastTime = time;
 

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
@@ -1,12 +1,8 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
-import Gio from "gi://Gio";
-import NM from "gi://NM";
 import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
-
-const NetworkManager = NM;
 
 // The five counters, in the order this widget's metrics and tooltip already use.
 const FIELDS = ['bytes_in', 'errors_in', 'bytes_out', 'errors_out', 'collisions'];
@@ -33,13 +29,6 @@ const Net = class SystemMonitor_Net extends ElementBase {
 
     constructor(extension, config) {
         super(extension, config);
-        this.ifs = [];
-        this.client = NM.Client.new(null);
-        this.update_iface_list();
-
-        if (!this.ifs.length)
-            this._detectInterfacesAsync();
-
         if (this.device_id !== 'all') {
             this.label.text = this.device_id;
             this.item_name = _('Net') + ' ' + this.device_id;
@@ -49,64 +38,8 @@ const Net = class SystemMonitor_Net extends ElementBase {
         this._last = new Map();
         this._lastTime = 0;
         this._noEdgeLogged = false;
+        this._missingLogged = false;
         this.tip_format([_('KiB/s'), '/s', _('KiB/s'), '/s', '/s']);
-        try {
-            let iface_list = this.client.get_devices();
-            this._nmDevices = [];
-            for (let j = 0; j < iface_list.length; j++) {
-                let device = iface_list[j];
-                device.connectObject('state-changed', this.update_iface_list.bind(this), this);
-                this._nmDevices.push(device);
-            }
-        } catch (e) {
-            console.error('Please install Network Manager Gobject Introspection Bindings: ' + e);
-        }
-    }
-
-    _detectInterfacesAsync() {
-        Gio.File.new_for_path('/proc/net/dev').load_contents_async(null, (file, result) => {
-            if (this._destroyed) return;
-            try {
-                let [, contents] = file.load_contents_finish(result);
-                let lines = new TextDecoder().decode(contents).split('\n');
-                for (let i = 2; i < lines.length - 1; i++) {
-                    let ifc = lines[i].replace(/^\s+/g, '').split(':')[0];
-                    if (ifc.indexOf('br') >= 0 || ifc.indexOf('lo') >= 0)
-                        continue;
-                    this._checkOperstate(ifc);
-                }
-            } catch { /* /proc/net/dev unavailable */ }
-        });
-    }
-
-    _checkOperstate(ifc) {
-        Gio.File.new_for_path('/sys/class/net/' + ifc + '/operstate')
-            .load_contents_async(null, (opFile, opResult) => {
-                if (this._destroyed) return;
-                try {
-                    let [, opContents] = opFile.load_contents_finish(opResult);
-                    if (new TextDecoder().decode(opContents).replace(/\s/g, '') === 'up') {
-                        if (this.device_id === 'all' || this.device_id === ifc)
-                            this.ifs.push(ifc);
-                    }
-                } catch { /* operstate file may not exist */ }
-            });
-    }
-
-    update_iface_list() {
-        try {
-            this.ifs = [];
-            let iface_list = this.client.get_devices();
-            for (let j = 0; j < iface_list.length; j++) {
-                if (iface_list[j].state === NetworkManager.DeviceState.ACTIVATED) {
-                    let iface = iface_list[j].get_ip_iface() || iface_list[j].get_iface();
-                    if (this.device_id === 'all' || this.device_id === iface)
-                        this.ifs.push(iface);
-                }
-            }
-        } catch {
-            console.error('Please install Network Manager Gobject Introspection Bindings');
-        }
     }
 
     collectAsync(callback) {
@@ -124,14 +57,11 @@ const Net = class SystemMonitor_Net extends ElementBase {
             // sign of one.
             let totals = [0, 0, 0, 0, 0];
             let current = new Map();
-            for (const iface of this.ifs) {
-                const now = reading.data.get(iface);
-                if (!now)
-                    continue;
+            for (const [iface, now] of reading.data) {
                 // A total counts the machine's edge, once. Summing a tunnel and
                 // the wifi carrying it reports the same bytes twice. Naming an
                 // interface is an explicit request for it, edge or not.
-                if (this.device_id === 'all' && !now.edge)
+                if (this.device_id === 'all' ? !now.edge : iface !== this.device_id)
                     continue;
                 current.set(iface, now);
                 const prev = this._last.get(iface);
@@ -147,10 +77,13 @@ const Net = class SystemMonitor_Net extends ElementBase {
                     totals[i] += now[FIELDS[i]] - prev[FIELDS[i]];
             }
             this._last = current;
-            if (this.device_id === 'all' && current.size === 0)
+            if (current.size) {
+                this._noEdgeLogged = false;
+                this._missingLogged = false;
+            } else if (this.device_id === 'all')
                 this._reportNoEdge(reading.data);
             else
-                this._noEdgeLogged = false;
+                this._reportMissing(reading.data);
 
             // The reading's own instant, not the clock now: a reading taken for
             // a faster sibling and consumed here is older than this tick, and
@@ -179,6 +112,18 @@ const Net = class SystemMonitor_Net extends ElementBase {
         sm_log(`${this.item_name}: no physical interface among ` +
                `${[...interfaces.keys()].join(', ')} — showing 0. If your traffic is ` +
                'between local machines, pick the bridge or tunnel it uses in preferences.', 'warn');
+    }
+
+    // An interface can be selected and then removed, or renamed by udev between
+    // opening preferences and the panel reading it. The panel can only show 0;
+    // which interfaces do exist is the difference between a mystery and a
+    // one-line diagnosis.
+    _reportMissing(interfaces) {
+        if (this._missingLogged)
+            return;
+        this._missingLogged = true;
+        sm_log(`${this.item_name}: /proc/net/dev lists ${[...interfaces.keys()].join(', ')} — ` +
+               `nothing for "${this.device_id}". Showing 0.`, 'warn');
     }
 
     _present(usage) {
@@ -240,14 +185,6 @@ const Net = class SystemMonitor_Net extends ElementBase {
         return str;
     }
 
-    destroy() {
-        if (this._nmDevices) {
-            for (const device of this._nmDevices)
-                device.disconnectObject(this);
-            this._nmDevices = null;
-        }
-        super.destroy();
-    }
 }
 
 export { Net };

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
@@ -3,6 +3,7 @@
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 import Gio from "gi://Gio";
 import NM from "gi://NM";
+import { sm_log } from '../utils.js';
 import { ElementBase } from '../base.js';
 
 const NetworkManager = NM;
@@ -47,6 +48,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
         this.cursor = extension._Samplers.net.cursor();
         this._last = new Map();
         this._lastTime = 0;
+        this._noEdgeLogged = false;
         this.tip_format([_('KiB/s'), '/s', _('KiB/s'), '/s', '/s']);
         try {
             let iface_list = this.client.get_devices();
@@ -126,6 +128,11 @@ const Net = class SystemMonitor_Net extends ElementBase {
                 const now = reading.data.get(iface);
                 if (!now)
                     continue;
+                // A total counts the machine's edge, once. Summing a tunnel and
+                // the wifi carrying it reports the same bytes twice. Naming an
+                // interface is an explicit request for it, edge or not.
+                if (this.device_id === 'all' && !now.edge)
+                    continue;
                 current.set(iface, now);
                 const prev = this._last.get(iface);
                 // No previous reading means the interface has just appeared,
@@ -140,6 +147,10 @@ const Net = class SystemMonitor_Net extends ElementBase {
                     totals[i] += now[FIELDS[i]] - prev[FIELDS[i]];
             }
             this._last = current;
+            if (this.device_id === 'all' && current.size === 0)
+                this._reportNoEdge(reading.data);
+            else
+                this._noEdgeLogged = false;
 
             // The reading's own instant, not the clock now: a reading taken for
             // a faster sibling and consumed here is older than this tick, and
@@ -155,6 +166,19 @@ const Net = class SystemMonitor_Net extends ElementBase {
 
             callback(this._present(usage));
         });
+    }
+
+    // A total of zero while traffic flows is the one way this rule looks broken,
+    // and it happens on a host whose traffic never reaches a NIC -- between
+    // local VMs over a bridge, say. The picker says what the total excludes;
+    // this is for whoever never opens it.
+    _reportNoEdge(interfaces) {
+        if (this._noEdgeLogged)
+            return;
+        this._noEdgeLogged = true;
+        sm_log(`${this.item_name}: no physical interface among ` +
+               `${[...interfaces.keys()].join(', ')} — showing 0. If your traffic is ` +
+               'between local machines, pick the bridge or tunnel it uses in preferences.', 'warn');
     }
 
     _present(usage) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
@@ -1,13 +1,14 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
 import { gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
-import GLib from "gi://GLib";
 import Gio from "gi://Gio";
-import GTop from "gi://GTop";
 import NM from "gi://NM";
 import { ElementBase } from '../base.js';
 
 const NetworkManager = NM;
+
+// The five counters, in the order this widget's metrics and tooltip already use.
+const FIELDS = ['bytes_in', 'errors_in', 'bytes_out', 'errors_out', 'collisions'];
 
 const Net = class SystemMonitor_Net extends ElementBase {
     static metadata = {
@@ -43,7 +44,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
             this.item_name = _('Net') + ' ' + this.device_id;
         }
 
-        this.gtop = new GTop.glibtop_netload();
+        this.cursor = extension._Samplers.net.cursor();
         this._last = [0, 0, 0, 0, 0];
         this._lastTime = 0;
         this.tip_format([_('KiB/s'), '/s', _('KiB/s'), '/s', '/s']);
@@ -106,28 +107,41 @@ const Net = class SystemMonitor_Net extends ElementBase {
         }
     }
 
-    collect() {
-        let accum = [0, 0, 0, 0, 0];
-        for (let ifn in this.ifs) {
-            GTop.glibtop_get_netload(this.gtop, this.ifs[ifn]);
-            accum[0] += this.gtop.bytes_in;
-            accum[1] += this.gtop.errors_in;
-            accum[2] += this.gtop.bytes_out;
-            accum[3] += this.gtop.errors_out;
-            accum[4] += this.gtop.collisions;
-        }
-
-        let time = GLib.get_monotonic_time() * 0.001024;
-        let delta = time - this._lastTime;
-        let usage = [0, 0, 0, 0, 0];
-        if (delta > 0) {
-            for (let i = 0; i < 5; i++) {
-                usage[i] = Math.round((accum[i] - this._last[i]) / delta);
-                this._last[i] = accum[i];
+    collectAsync(callback) {
+        this.cursor.sample(reading => {
+            if (this._destroyed || !reading?.data) {
+                callback(null);
+                return;
             }
-        }
-        this._lastTime = time;
 
+            let accum = [0, 0, 0, 0, 0];
+            for (const iface of this.ifs) {
+                const counters = reading.data.get(iface);
+                if (!counters)
+                    continue;
+                for (let i = 0; i < 5; i++)
+                    accum[i] += counters[FIELDS[i]];
+            }
+
+            // The reading's own instant, not the clock now: a reading taken for
+            // a faster sibling and consumed here is older than this tick, and
+            // dividing by the wrong interval understates the rate.
+            let time = reading.time * 0.001024;
+            let delta = time - this._lastTime;
+            let usage = [0, 0, 0, 0, 0];
+            if (delta > 0) {
+                for (let i = 0; i < 5; i++) {
+                    usage[i] = Math.round((accum[i] - this._last[i]) / delta);
+                    this._last[i] = accum[i];
+                }
+            }
+            this._lastTime = time;
+
+            callback(this._present(usage));
+        });
+    }
+
+    _present(usage) {
         const Style = this.extension._Style;
         let downVal = usage[0];
         let upVal = usage[2];

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/network.js
@@ -80,10 +80,19 @@ const Net = class SystemMonitor_Net extends ElementBase {
             if (current.size) {
                 this._noEdgeLogged = false;
                 this._missingLogged = false;
-            } else if (this.device_id === 'all')
+            } else if (this.device_id === 'all') {
+                // An aggregate is a fold over a set, and the empty set folds to
+                // a real zero: this host's traffic genuinely never reaches its
+                // edge.
                 this._reportNoEdge(reading.data);
-            else
+            } else {
+                // A named interface that is not in /proc/net/dev has not been
+                // measured, which is not the same as having carried nothing.
                 this._reportMissing(reading.data);
+                this._lastTime = reading.time * 0.001024;
+                callback(null);
+                return;
+            }
 
             // The reading's own instant, not the clock now: a reading taken for
             // a faster sibling and consumed here is older than this tick, and
@@ -123,7 +132,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
             return;
         this._missingLogged = true;
         sm_log(`${this.item_name}: /proc/net/dev lists ${[...interfaces.keys()].join(', ')} — ` +
-               `nothing for "${this.device_id}". Showing 0.`, 'warn');
+               `nothing for "${this.device_id}". Showing --.`, 'warn');
     }
 
     _present(usage) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/prometheus.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/prometheus.js
@@ -27,23 +27,16 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
                 return;
             }
             if (!reading?.data) {
-                callback(this._failureData());
+                callback(null);
                 return;
             }
             let val = this._parseMetric(reading.data.lines());
             if (val === null) {
-                callback(this._failureData());
+                callback(null);
                 return;
             }
             callback({metrics: {value: val}, display: this._formatValue(val)});
         });
-    }
-
-    // No metrics key: a failed scrape must not chart a fake 0
-    // (indistinguishable from a real zero reading) -- leave the chart at
-    // its last value and signal the failure via the panel text.
-    _failureData() {
-        return {display: '--'};
     }
 
     _parseMetric(lines) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/prometheus.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/prometheus.js
@@ -1,11 +1,6 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
 import { ElementBase } from '../base.js';
-import { sm_log } from '../utils.js';
-
-import Soup from 'gi://Soup?version=3.0';
 
 const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
     static metadata = {
@@ -19,50 +14,28 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
 
     constructor(extension, config) {
         super(extension, config);
-        this._session = new Soup.Session({timeout: 10});
-        this._cancellable = new Gio.Cancellable();
         this._server = config.server || 'http://localhost:9100';
         this._metric = config.metric || 'up';
+        this.cursor = extension._Samplers.prometheus(this._server).cursor();
         this._setLabels();
     }
 
     collectAsync(callback) {
-        if (!this._session) {
-            callback(this._failureData());
-            return;
-        }
-
-        let uri = this._server + '/metrics';
-        let message = Soup.Message.new('GET', uri);
-        if (!message) {
-            callback(this._failureData());
-            return;
-        }
-
-        this._session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, this._cancellable, (session, result) => {
-            try {
-                let bytes = session.send_and_read_finish(result);
-                if (message.get_status() !== Soup.Status.OK) {
-                    callback(this._failureData());
-                    return;
-                }
-                let text = new TextDecoder().decode(bytes.get_data());
-                let val = this._parseMetric(text);
-                if (val === null) {
-                    callback(this._failureData());
-                    return;
-                }
-                this._fetchErrorLogged = false;
-                let display = this._formatValue(val);
-                callback({metrics: {value: val}, display: display});
-            } catch (e) {
-                if (!this._fetchErrorLogged &&
-                    (!(e instanceof Gio.IOErrorEnum) || e.code !== Gio.IOErrorEnum.CANCELLED)) {
-                    sm_log(`Prometheus fetch error: ${e.message}`, 'warn');
-                    this._fetchErrorLogged = true;
-                }
-                callback(this._failureData());
+        this.cursor.sample(reading => {
+            if (this._destroyed) {
+                callback(null);
+                return;
             }
+            if (!reading?.data) {
+                callback(this._failureData());
+                return;
+            }
+            let val = this._parseMetric(reading.data.lines());
+            if (val === null) {
+                callback(this._failureData());
+                return;
+            }
+            callback({metrics: {value: val}, display: this._formatValue(val)});
         });
     }
 
@@ -73,7 +46,7 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
         return {display: '--'};
     }
 
-    _parseMetric(text) {
+    _parseMetric(lines) {
         let needle = this._metric;
         let labelFilters = null;
         let braceIdx = needle.indexOf('{');
@@ -83,7 +56,6 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
             labelFilters = labelStr.split(',').map(s => s.trim()).filter(s => s);
         }
 
-        let lines = text.split('\n');
         for (let line of lines) {
             if (line.startsWith('#') || line.length === 0)
                 continue;
@@ -128,8 +100,13 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
     }
 
     onSettingsChanged(newConfig) {
-        if (this.config.server !== newConfig.server)
+        if (this.config.server !== newConfig.server) {
             this._server = newConfig.server || 'http://localhost:9100';
+            // A cursor is bound to its sampler, and a different server is a
+            // different sampler -- keeping the old one would keep scraping the
+            // old server.
+            this.cursor = this.extension._Samplers.prometheus(this._server).cursor();
+        }
         if (this.config.metric !== newConfig.metric) {
             this._metric = newConfig.metric || 'up';
             this._setLabels();
@@ -138,14 +115,8 @@ const Prometheus = class SystemMonitor_Prometheus extends ElementBase {
     }
 
     destroy() {
-        if (this._cancellable) {
-            this._cancellable.cancel();
-            this._cancellable = null;
-        }
-        if (this._session) {
-            this._session.abort();
-            this._session = null;
-        }
+        // The session and the scrape in flight belong to the sampler now, and
+        // are shared with every other widget on this server.
         super.destroy();
     }
 };

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
@@ -18,6 +18,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         super(extension, config);
         this.max = 100;
         this.sensor_label = this.device_id;
+        this.cursor = extension._Samplers.sensors.cursor();
         this.sensors = null;
         check_sensors_async('temp', sensors => {
             this.sensors = sensors;
@@ -54,7 +55,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             callback(null);
             return;
         }
-        read_sensor_async(sensorInfo, value => {
+        read_sensor_async(this.cursor, sensorInfo, value => {
             if (this._destroyed) { callback(null); return; }
             if (value === null) {
                 if (this._display_error) {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
@@ -40,8 +40,26 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         this.reset_style();
     }
 
+    // Not a bad selection but a machine with nothing to select: no hwmon
+    // temperature inputs and no lm_sensors, which is ordinary on a virtual
+    // machine. The panel can only show "--", and without this there is nothing
+    // anywhere saying why.
+    _reportNoSensors() {
+        if (!this._display_error)
+            return;
+        this._display_error = false;
+        sm_log(`${this.item_name}: this machine reports no temperature sensors. Showing --. ` +
+               'Installing lm_sensors may expose more of them.', 'warn');
+    }
+
     collectAsync(callback) {
-        if (!this.sensors || Object.keys(this.sensors).length === 0) {
+        if (!this.sensors) {
+            // Enumeration has not come back yet, which is not a fault.
+            callback(null);
+            return;
+        }
+        if (Object.keys(this.sensors).length === 0) {
+            this._reportNoSensors();
             callback(null);
             return;
         }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/widgets/thermal.js
@@ -96,8 +96,6 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
     }
 
     _formatTemp() {
-        if (this._temperature === null)
-            return '-- ';
         let t = this._temperature;
         if (this.fahrenheit_unit)
             t = Math.round(t * 1.8 + 32);

--- a/testing/vm/README.md
+++ b/testing/vm/README.md
@@ -121,7 +121,7 @@ What it does:
 3. Deploys via rsync + compiles schemas (both in extension dir and system-wide)
 4. If first deploy: restarts GDM so GNOME Shell discovers the new extension
 5. Enables extension via `gnome-extensions enable`
-6. Runs health checks (gnome-shell alive, extension ACTIVE, no JS errors)
+6. Runs health checks (gnome-shell alive, extension ACTIVE, no JS errors, preferences opens)
 7. Captures screenshot via `virsh screenshot` (PPM -> PNG)
 8. Captures GNOME Shell journal logs
 9. Prints structured results
@@ -265,7 +265,8 @@ testing/vm/
     vm-deploy.sh            # Build + rsync + schema install + enable
     vm-screenshot.sh        # virsh screenshot -> PNG
     vm-logs.sh              # GNOME Shell journal capture
-    vm-health.sh            # Health checks (alive, active, no JS errors)
+    vm-health.sh            # Health checks (alive, active, no JS errors, prefs opens)
+    prefs-smoke.sh          # Opens preferences on the VM; runs in its own process
   results/                  # Screenshots and logs (gitignored)
 ```
 

--- a/testing/vm/README.md
+++ b/testing/vm/README.md
@@ -165,11 +165,18 @@ Generates an HTML comparison report at `testing/vm/results/<label>/report.html` 
 ```bash
 ./testing/vm/vm-config.sh --vm gssmn-fedora42 --preset all-visible --screenshot
 ./testing/vm/vm-config.sh --vm gssmn-fedora42 --preset prometheus --screenshot
+./testing/vm/vm-config.sh --vm gssmn-fedora42 --preset menu-grouping --open-menu --screenshot
 ./testing/vm/vm-config.sh --vm gssmn-fedora42 my-custom-config.json
 ./testing/vm/vm-config.sh --list-presets
 ```
 
 Pushes monitor configurations from JSON files to a VM's GSettings, replacing the current monitor setup. Avoids manual GVariant escaping. Use `--screenshot` to snap the result.
+
+**`--open-menu`** opens the extension's popup menu before the screenshot, since none of it
+shows in a panel shot. There is no pointer channel into the guest, so the menu is reached by
+keyboard: focus the top bar, walk to the far right, step back onto the extension's button,
+press Enter. `vm-test.sh --screenshot-only --open-menu` does the same without pushing a
+config. Set `TRAY_MENU_WALK` if a panel ever holds more than eight items.
 
 **Presets** live in `testing/vm/configs/*.json`. Each is a JSON file with a `monitors` array (and optional `settings` for globals like `compact-display`). To add a new preset, just drop a JSON file in that directory.
 

--- a/testing/vm/configs/absence-probe.json
+++ b/testing/vm/configs/absence-probe.json
@@ -1,0 +1,63 @@
+{
+    "description": "Devices that are not there: a missing disk, a core the machine lacks, a bogus sensor, an absent interface",
+    "monitors": [
+        {
+            "uuid": "probe-disk-all",
+            "type": "disk",
+            "devices": [{"id": "all", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 100,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        },
+        {
+            "uuid": "probe-cpu",
+            "type": "cpu",
+            "devices": [{"id": "3", "show-text": true}, {"id": "63", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 60,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "probe-net",
+            "type": "net",
+            "devices": [{"id": "all", "show-text": true}, {"id": "enp99s0", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 60,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"down": "#fce94f", "downerrors": "#ff6e00", "up": "#fb74fb", "uperrors": "#e0006e", "collisions": "#ff0000"},
+            "speed-in-bits": false
+        },
+        {
+            "uuid": "probe-thermal",
+            "type": "thermal",
+            "devices": [{"id": "nosuchchip - temp1", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 60,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"tz0": "#f2002e"},
+            "fahrenheit-unit": false,
+            "threshold": 0
+        },
+        {
+            "uuid": "probe-gpu",
+            "type": "gpu",
+            "devices": [{"id": "0", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 60,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"used": "#00b35b", "memory": "#00ff82"}
+        }
+    ]
+}

--- a/testing/vm/configs/all-cores.json
+++ b/testing/vm/configs/all-cores.json
@@ -1,0 +1,33 @@
+{
+    "description": "One CPU monitor covering the total plus every core, labels off, at the width preferences would pick for five devices",
+    "monitors": [
+        {
+            "uuid": "cfg-cpu-cores",
+            "type": "cpu",
+            "devices": [
+                {"id": "all", "show-text": true},
+                {"id": "0", "show-text": false},
+                {"id": "1", "show-text": false},
+                {"id": "2", "show-text": false},
+                {"id": "3", "show-text": false}
+            ],
+            "display": true,
+            "style": "graph",
+            "graph-width": 64,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-mem-def",
+            "type": "memory",
+            "devices": [{"id": "default", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 100,
+            "refresh-time": 3000,
+            "show-menu": true,
+            "colors": {"program": "#00b35b", "buffer": "#00ff82", "cache": "#aaf5d0"}
+        }
+    ]
+}

--- a/testing/vm/configs/disk-layers.json
+++ b/testing/vm/configs/disk-layers.json
@@ -1,0 +1,38 @@
+{
+    "description": "A disk total beside the medium it sums and the layers it must not, for the double-count test. Build the layered case on the VM first: 'truncate -s 64M /tmp/back{1,2,3}.img; L1=$(losetup -f --show /tmp/back1.img); dmsetup create m04btest --table \"0 $(blockdev --getsz $L1) linear $L1 0\"; mdadm --create /dev/md0 --level=1 --raid-devices=2 --run /dev/loop1 /dev/loop2; modprobe nbd'. Then push a known volume with 'dd oflag=direct' and read the rows together: the total must match the vda row, not the sum of vda and its partitions, because the block layer accounts one request at every device it traverses. The layer rows still report their own I/O, which is what a user who wants the view from inside an encrypted volume selects. Teardown: 'mdadm --stop /dev/md0; dmsetup remove m04btest; losetup -D; rmmod nbd'.",
+    "monitors": [
+        {
+            "uuid": "cfg-disk-total",
+            "type": "disk",
+            "devices": ["all"],
+            "display": true,
+            "style": "both",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        },
+        {
+            "uuid": "cfg-disk-medium",
+            "type": "disk",
+            "devices": [{"id": "vda", "show-text": true}],
+            "display": true,
+            "style": "digit",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        },
+        {
+            "uuid": "cfg-disk-layers",
+            "type": "disk",
+            "devices": [{"id": "vda4", "show-text": true}, {"id": "dm-0", "show-text": true}, {"id": "md0", "show-text": true}],
+            "display": true,
+            "style": "digit",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        }
+    ]
+}

--- a/testing/vm/configs/menu-grouping.json
+++ b/testing/vm/configs/menu-grouping.json
@@ -1,0 +1,49 @@
+{
+    "description": "A multi-device CPU monitor and a multi-device Net monitor beside single-device ones, all shown in the menu. Open the tray menu to read it: --open-menu --screenshot. CPU's cells are narrow so they wrap into several columns; Net's carry two rates and a unit each, so they fall to one column. Memory is the unchanged single-device row to compare against.",
+    "monitors": [
+        {
+            "uuid": "cfg-menu-cpu",
+            "type": "cpu",
+            "devices": [
+                {"id": "all", "show-text": true},
+                {"id": "0", "show-text": false},
+                {"id": "1", "show-text": false},
+                {"id": "2", "show-text": false},
+                {"id": "3", "show-text": false}
+            ],
+            "display": true,
+            "style": "graph",
+            "graph-width": 64,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-menu-net",
+            "type": "net",
+            "devices": [
+                {"id": "all", "show-text": true},
+                {"id": "enp1s0", "show-text": false},
+                {"id": "lo", "show-text": false}
+            ],
+            "display": true,
+            "style": "digit",
+            "graph-width": 60,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"down": "#fce94f", "downerrors": "#ff6e00", "up": "#fb74fb", "uperrors": "#e0006e", "collisions": "#ff0000"},
+            "speed-in-bits": false
+        },
+        {
+            "uuid": "cfg-menu-mem",
+            "type": "memory",
+            "devices": [{"id": "default", "show-text": true}],
+            "display": true,
+            "style": "both",
+            "graph-width": 100,
+            "refresh-time": 1500,
+            "show-menu": true,
+            "colors": {"program": "#00b35b", "buffer": "#00ff82", "cache": "#aaf5d0"}
+        }
+    ]
+}

--- a/testing/vm/configs/net-layers.json
+++ b/testing/vm/configs/net-layers.json
@@ -1,0 +1,41 @@
+{
+    "description": "A net total beside the hardware interface it sums and the virtual interfaces it must not, for the double-count test. Build the layered case on the VM first: 'ip link add br0 type bridge; ip link add veth0 type veth peer name veth1; ip link set veth1 master br0; ip tunnel add tun0 mode ipip remote <peer> local <self>' and bring them up. Then push a known volume through the tunnel and read the three rows together: the total must match the hardware row, not their sum, because the tunnel's bytes leave over the hardware as well. The virtual rows still report their own traffic, which is what a user who wants the inner view of a tunnel selects.",
+    "monitors": [
+        {
+            "uuid": "cfg-net-total",
+            "type": "net",
+            "devices": ["all"],
+            "display": true,
+            "style": "both",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"down": "#fce94f", "downerrors": "#ff6e00", "up": "#fb74fb", "uperrors": "#e0006e", "collisions": "#ff0000"},
+            "speed-in-bits": false
+        },
+        {
+            "uuid": "cfg-net-edge",
+            "type": "net",
+            "devices": [{"id": "enp1s0", "show-text": true}],
+            "display": true,
+            "style": "digit",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"down": "#fce94f", "downerrors": "#ff6e00", "up": "#fb74fb", "uperrors": "#e0006e", "collisions": "#ff0000"},
+            "speed-in-bits": false
+        },
+        {
+            "uuid": "cfg-net-virtual",
+            "type": "net",
+            "devices": [{"id": "br0", "show-text": true}, {"id": "tun0", "show-text": true}],
+            "display": true,
+            "style": "digit",
+            "graph-width": 100,
+            "refresh-time": 1000,
+            "show-menu": true,
+            "colors": {"down": "#fce94f", "downerrors": "#ff6e00", "up": "#fb74fb", "uperrors": "#e0006e", "collisions": "#ff0000"},
+            "speed-in-bits": false
+        }
+    ]
+}

--- a/testing/vm/configs/shared-sources.json
+++ b/testing/vm/configs/shared-sources.json
@@ -1,0 +1,71 @@
+{
+    "description": "Twenty CPU widgets over one shared source, plus two disk widgets, for measuring steady-state cost. Four monitors covering the same device set is what a user writing four differently-styled CPU rows produces, and it is exactly the case the sampler collapses.",
+    "monitors": [
+        {
+            "uuid": "cfg-cpu-a",
+            "type": "cpu",
+            "devices": ["all", "0", "1", "2", "3"],
+            "display": true,
+            "style": "graph",
+            "graph-width": 20,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-cpu-b",
+            "type": "cpu",
+            "devices": ["all", "0", "1", "2", "3"],
+            "display": true,
+            "style": "graph",
+            "graph-width": 20,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-cpu-c",
+            "type": "cpu",
+            "devices": ["all", "0", "1", "2", "3"],
+            "display": true,
+            "style": "graph",
+            "graph-width": 20,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-cpu-d",
+            "type": "cpu",
+            "devices": ["all", "0", "1", "2", "3"],
+            "display": true,
+            "style": "graph",
+            "graph-width": 20,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"user": "#0072b3", "system": "#0092e6", "nice": "#00a3ff", "iowait": "#002f3d", "other": "#001d26"}
+        },
+        {
+            "uuid": "cfg-disk-all",
+            "type": "disk",
+            "devices": ["all"],
+            "display": true,
+            "style": "digit",
+            "graph-width": 40,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        },
+        {
+            "uuid": "cfg-disk-vda",
+            "type": "disk",
+            "devices": ["vda"],
+            "display": true,
+            "style": "digit",
+            "graph-width": 40,
+            "refresh-time": 1500,
+            "show-menu": false,
+            "colors": {"read": "#c65000", "write": "#ff6700"}
+        }
+    ]
+}

--- a/testing/vm/lib/prefs-smoke.sh
+++ b/testing/vm/lib/prefs-smoke.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Open the extension's preferences window and report whether it came up.
+# Runs on the VM. Usage: prefs-smoke.sh <extension-uuid>
+#
+# Preferences runs in its own process (org.gnome.Shell.Extensions), which no
+# other health check ever starts, so a fault confined to prefs.js -- a gettext
+# call at module scope, a bad import, a typo in a widget property -- leaves
+# gnome-shell perfectly healthy and every shell-side check green.
+#
+# Prints "PREFS_OK" or "PREFS_FAIL" followed by whatever went wrong.
+
+set -uo pipefail
+UUID="${1:?extension uuid}"
+PATTERN="org.gnome.Shell.Extensions"
+
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-0}"
+
+# pkill -f would match this script's own command line; match the binary's args
+# only via pgrep on the full line, excluding our own pid.
+kill_prefs() {
+    for pid in $(pgrep -f "$PATTERN" 2>/dev/null); do
+        [ "$pid" = "$$" ] && continue
+        kill "$pid" 2>/dev/null
+    done
+}
+
+kill_prefs
+sleep 1
+
+BEFORE=$(mktemp)
+journalctl --user -b --no-pager > "$BEFORE" 2>/dev/null
+
+gnome-extensions prefs "$UUID" >/dev/null 2>&1
+sleep 6
+
+ERRORS=$(journalctl --user -b --no-pager 2>/dev/null \
+    | grep -vxF -f "$BEFORE" 2>/dev/null \
+    | grep -iE "Failed to open preferences|JS ERROR" \
+    | head -10)
+
+ALIVE=0
+for pid in $(pgrep -f "$PATTERN" 2>/dev/null); do
+    [ "$pid" = "$$" ] && continue
+    ALIVE=$((ALIVE + 1))
+done
+
+kill_prefs
+rm -f "$BEFORE"
+
+if [ -n "$ERRORS" ]; then
+    echo "PREFS_FAIL"
+    echo "$ERRORS"
+    exit 1
+fi
+if [ "$ALIVE" -eq 0 ]; then
+    echo "PREFS_FAIL"
+    echo "preferences process did not stay running"
+    exit 1
+fi
+echo "PREFS_OK"

--- a/testing/vm/lib/vm-health.sh
+++ b/testing/vm/lib/vm-health.sh
@@ -36,6 +36,35 @@ check_no_js_errors() {
     return 0
 }
 
+# Open the preferences window and check it actually came up.
+#
+# The shell-side checks above all pass while prefs is completely broken --
+# preferences runs in its own process that nothing else here ever starts. A
+# gettext call at module scope, a bad import, a typo in a widget property: none
+# of it touches gnome-shell, so every other check reports healthy.
+#
+# Shipped as a script rather than an inline command because vm_ssh joins its
+# arguments, which mangles anything multi-line.
+#
+# Returns 0 if preferences opened without error, 1 otherwise.
+check_prefs_open() {
+    local vm_name="$1"
+    local script="$SCRIPT_DIR/lib/prefs-smoke.sh"
+    [[ -f "$script" ]] || script="$(dirname "${BASH_SOURCE[0]}")/prefs-smoke.sh"
+
+    vm_rsync "$vm_name" "$script" "/tmp/_sm_prefs_smoke.sh" &>/dev/null
+
+    local out
+    out=$(vm_ssh "$vm_name" "bash /tmp/_sm_prefs_smoke.sh $EXT_UUID" 2>/dev/null)
+
+    if [[ "$out" == *PREFS_OK* ]]; then
+        return 0
+    fi
+    log_error "Preferences did not open cleanly:"
+    echo "$out" | grep -v '^PREFS_FAIL$' >&2
+    return 1
+}
+
 # Detect if GNOME Shell crashed and restarted by comparing PIDs.
 # Usage: detect_crash <vm_name> <pre_pid>
 # Returns 0 if no crash, 1 if crash detected.
@@ -101,6 +130,14 @@ check_health() {
         echo "JS Errors: none"
     else
         echo "JS Errors: FOUND (see logs)"
+        status=1
+    fi
+
+    # Check preferences opens (its own process; nothing above touches it)
+    if check_prefs_open "$vm_name"; then
+        echo "Preferences: opens"
+    else
+        echo "Preferences: FAILED TO OPEN"
         status=1
     fi
 

--- a/testing/vm/lib/vm-menu.sh
+++ b/testing/vm/lib/vm-menu.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Open the extension's tray menu inside a VM, so it can be screenshotted.
+#
+# Usage: source vm-common.sh; source vm-menu.sh; open_tray_menu <vm_name>
+#
+# The popup menu is where multi-device monitors report, and none of it is
+# visible in a panel screenshot. There is no pointer channel into the guest --
+# `virsh` sends key events only -- so the menu is reached the way a keyboard
+# user reaches it: focus the top bar, walk to the button, press Enter.
+#
+# GNOME's own status area is always the last item in the panel, and this
+# extension inserts itself immediately before it, so walking to the far right
+# and stepping back once lands on the extension whatever else is in the panel.
+# Arrow navigation stops at the ends rather than wrapping, which is what makes
+# a fixed number of presses safe: press more than there are items.
+
+# Presses used to reach the far right of the panel. Any number at or above the
+# panel's item count works; the walk stops at the end.
+TRAY_MENU_WALK="${TRAY_MENU_WALK:-8}"
+
+# Send one key combination to the guest.
+_send_key() {
+    local vm_name="$1"
+    shift
+    $VIRSH send-key "$vm_name" "$@" >/dev/null
+    sleep 0.4
+}
+
+# Open the extension's tray menu. Leaves it open.
+# Usage: open_tray_menu <vm_name>
+open_tray_menu() {
+    local vm_name="$1"
+
+    # Any menu already open would swallow the navigation keys.
+    _send_key "$vm_name" KEY_ESC
+
+    _send_key "$vm_name" KEY_LEFTCTRL KEY_LEFTALT KEY_TAB
+    for ((i = 0; i < TRAY_MENU_WALK; i++)); do
+        _send_key "$vm_name" KEY_RIGHT
+    done
+    _send_key "$vm_name" KEY_LEFT
+    _send_key "$vm_name" KEY_ENTER
+
+    # The menu animates open, and a screenshot taken during the animation shows
+    # a half-drawn table.
+    sleep 1
+    log_ok "Tray menu opened on '$vm_name'"
+}
+
+# Close whatever menu is open.
+# Usage: close_tray_menu <vm_name>
+close_tray_menu() {
+    local vm_name="$1"
+    _send_key "$vm_name" KEY_ESC
+}

--- a/testing/vm/vm-config.sh
+++ b/testing/vm/vm-config.sh
@@ -10,6 +10,7 @@
 #   --vm NAME          VM to use (default: first in vms.conf)
 #   --preset NAME      Use a preset from testing/vm/configs/
 #   --screenshot       Take a screenshot after applying config
+#   --open-menu        Open the extension's tray menu before screenshotting
 #   --label LABEL      Label for screenshot file (default: preset/file name)
 #   --list-presets     List available preset names
 #
@@ -26,11 +27,13 @@ CONFIGS_DIR="$SCRIPT_DIR/configs"
 
 source "$SCRIPT_DIR/lib/vm-common.sh"
 source "$SCRIPT_DIR/lib/vm-screenshot.sh"
+source "$SCRIPT_DIR/lib/vm-menu.sh"
 
 TARGET_VM=""
 PRESET=""
 CONFIG_FILE=""
 SCREENSHOT=false
+OPEN_MENU=false
 LABEL=""
 
 while [[ $# -gt 0 ]]; do
@@ -38,6 +41,7 @@ while [[ $# -gt 0 ]]; do
         --vm) TARGET_VM="$2"; shift 2 ;;
         --preset) PRESET="$2"; shift 2 ;;
         --screenshot) SCREENSHOT=true; shift ;;
+        --open-menu) OPEN_MENU=true; shift ;;
         --label) LABEL="$2"; shift 2 ;;
         --list-presets)
             echo "Available presets:"
@@ -63,6 +67,7 @@ print(desc)
             echo "  --vm NAME          VM to use (default: first in vms.conf)"
             echo "  --preset NAME      Use a preset from testing/vm/configs/"
             echo "  --screenshot       Take a screenshot after applying"
+            echo "  --open-menu        Open the tray menu before screenshotting"
             echo "  --label LABEL      Label for screenshot (default: config name)"
             echo "  --list-presets     List available presets"
             echo ""
@@ -70,6 +75,7 @@ print(desc)
             echo "  $0 --preset all-visible"
             echo "  $0 --preset prometheus --screenshot"
             echo "  $0 my-config.json --screenshot"
+            echo "  $0 --preset all-cores --open-menu --screenshot"
             exit 0
             ;;
         -*) log_error "Unknown option: $1"; exit 2 ;;
@@ -119,8 +125,17 @@ vm_rsync "$TARGET_VM" "$APPLY_SCRIPT" "/tmp/_sm_apply.py"
 vm_ssh "$TARGET_VM" "python3 /tmp/_sm_apply.py /tmp/_sm_config.json"
 log_ok "Config applied"
 
-if $SCREENSHOT; then
+if $OPEN_MENU; then
+    # Widgets fill their menu cells on their own refresh tick, so a menu opened
+    # the instant the config lands shows a table that is still filling in.
     sleep 3
+    open_tray_menu "$TARGET_VM"
+fi
+
+if $SCREENSHOT; then
+    if ! $OPEN_MENU; then
+        sleep 3
+    fi
     SCREENSHOT_PATH=$(take_screenshot "$TARGET_VM" "$LABEL")
     log_ok "Screenshot: $SCREENSHOT_PATH"
 fi

--- a/testing/vm/vm-test.sh
+++ b/testing/vm/vm-test.sh
@@ -27,6 +27,7 @@ source "$SCRIPT_DIR/lib/vm-common.sh"
 source "$SCRIPT_DIR/lib/vm-snapshot.sh"
 source "$SCRIPT_DIR/lib/vm-deploy.sh"
 source "$SCRIPT_DIR/lib/vm-screenshot.sh"
+source "$SCRIPT_DIR/lib/vm-menu.sh"
 source "$SCRIPT_DIR/lib/vm-logs.sh"
 source "$SCRIPT_DIR/lib/vm-health.sh"
 
@@ -34,6 +35,7 @@ source "$SCRIPT_DIR/lib/vm-health.sh"
 TARGET_VM=""
 NO_RESTORE=false
 SCREENSHOT_ONLY=false
+OPEN_MENU=false
 LOGS_ONLY=false
 LABEL="test"
 TIMEOUT=180
@@ -44,6 +46,7 @@ while [[ $# -gt 0 ]]; do
         --vm) TARGET_VM="$2"; shift 2 ;;
         --no-restore) NO_RESTORE=true; shift ;;
         --screenshot-only) SCREENSHOT_ONLY=true; shift ;;
+        --open-menu) OPEN_MENU=true; shift ;;
         --logs-only) LOGS_ONLY=true; shift ;;
         --label) LABEL="$2"; shift 2 ;;
         --timeout) TIMEOUT="$2"; shift 2 ;;
@@ -57,6 +60,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --vm NAME          VM to use (default: first in vms.conf)"
             echo "  --no-restore       Skip snapshot restore (faster iteration)"
             echo "  --screenshot-only  Just take a screenshot"
+            echo "  --open-menu        Open the tray menu first (with --screenshot-only)"
             echo "  --logs-only        Just capture logs"
             echo "  --label LABEL      Label for output files (default: test)"
             echo "  --timeout SECS     SSH timeout (default: 180)"
@@ -100,6 +104,9 @@ if $SCREENSHOT_ONLY; then
     if ! vm_is_running "$VM_NAME"; then
         log_error "VM is not running"
         exit 2
+    fi
+    if $OPEN_MENU; then
+        open_tray_menu "$VM_NAME"
     fi
     SCREENSHOT_PATH=$(take_screenshot "$VM_NAME" "$LABEL")
     echo ""

--- a/testing/vm/vms.conf
+++ b/testing/vm/vms.conf
@@ -19,7 +19,7 @@
 gssmn-fedora39|fedora39|45|https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2|4|4096|20|2222
 gssmn-fedora40|fedora40|46|https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2|4|4096|20|2223
 gssmn-fedora41|fedora41|47|https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/41/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2|4|4096|20|2224
-gssmn-fedora42|fedora42|48|https://download.fedoraproject.org/pub/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2|4|4096|20|2225
+gssmn-fedora42|fedora42|48|https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2|4|4096|20|2225
 gssmn-fedora43|fedora43|49|https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2|4|4096|20|2226
 gssmn-fedora44|fedora43|50|https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2|4|4096|20|2228
 


### PR DESCRIPTION
I started out just wanting to fix #150 because I was the one that broke it, but ended up going down a rabbit hole.

Full list of changes are in the new Changelog file.

I'm happy to tweak it or break it up as you see fit, but after working on it all day, I just wanted to get the PR in.

### What I tested

- [x] Verified no regressions to existing functionality.
- [x] Tested on the following Gnome Shell versions: (49,50)

### Screenshots
Multicore, multi-block device, and multi-gpu, each with only one preference config
<img width="1210" height="52" alt="image" src="https://github.com/user-attachments/assets/64856ec6-f5de-4af4-b874-2eb9dd1e8dab" />


<img width="712" height="190" alt="image" src="https://github.com/user-attachments/assets/cc75a74c-6ebe-48be-b5f6-286bad5fe967" />

<img width="783" height="933" alt="image" src="https://github.com/user-attachments/assets/ef29f188-80a8-4cda-bba6-16b7bd82bccd" />

Menu showing consolidated groups and some missing hardware, now correctly showing blanks:
<img width="490" height="657" alt="image" src="https://github.com/user-attachments/assets/aebee600-e0f0-4b95-b9b2-50ca4fbef4ee" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/152)
<!-- Reviewable:end -->
