### PR TITLE
Fix panel freezing permanently when the GC sweep kills update timers

### DIFF
--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -60,6 +60,33 @@ export function l_limit(t) {
     return (t > 0) ? t : 1000;
 }
 
+/**
+ * Whether a GLib source id still refers to a live source on the default main
+ * context. GJS refuses to enter JS while the GC is sweeping, and a refused
+ * SourceFunc yields no return value, which GLib reads as G_SOURCE_REMOVE — so
+ * a source can be destroyed without the extension ever being told. Anything
+ * holding a source id has to be able to ask.
+ *
+ * id - GLib source id, or a falsy value
+ */
+export function source_is_alive(id) {
+    if (!id)
+        return false;
+    return GLib.MainContext.default().find_source_by_id(id) !== null;
+}
+
+/**
+ * Removes a GLib source only if it is still alive, so that a source already
+ * destroyed behind our back does not produce a "Source ID N was not found when
+ * attempting to remove it" critical.
+ *
+ * id - GLib source id, or a falsy value
+ */
+export function source_remove_if_alive(id) {
+    if (source_is_alive(id))
+        GLib.Source.remove(id);
+}
+
 export function change_text() {
     this.label.visible = this.config['show-text'];
 }
@@ -860,9 +887,7 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
      * max - Maximum value to preserve during cooldown
      */
     restart_cooldown_timer(max = 0) {
-        if (this.graph_scale_cooldown_timer_id) {
-            GLib.Source.remove(this.graph_scale_cooldown_timer_id);
-        }
+        source_remove_if_alive(this.graph_scale_cooldown_timer_id);
         this.graph_scale_max_including_cooldown = max;
         this.graph_scale_cooldown_delay_minutes = this.extension._Schema.get_int('graph-cooldown-delay-m');
         if (this.graph_scale_cooldown_delay_minutes !== 0) {
@@ -1100,21 +1125,13 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         if (this.chart)
             this.chart.destroy();
         TipBox.prototype.destroy.call(this);
-        if (this._initialUpdateId) {
-            GLib.Source.remove(this._initialUpdateId);
-            this._initialUpdateId = null;
-        }
-        if (this.timeout) {
-            GLib.Source.remove(this.timeout);
-            this.timeout = null;
-        }
-        if (this.graph_scale_cooldown_timer_id) {
-            GLib.Source.remove(this.graph_scale_cooldown_timer_id);
-            this.graph_scale_cooldown_timer_id = null;
-        }
-        if (this._asyncTimeoutId) {
-            GLib.Source.remove(this._asyncTimeoutId);
-            this._asyncTimeoutId = null;
-        }
+        source_remove_if_alive(this._initialUpdateId);
+        this._initialUpdateId = null;
+        source_remove_if_alive(this.timeout);
+        this.timeout = null;
+        source_remove_if_alive(this.graph_scale_cooldown_timer_id);
+        this.graph_scale_cooldown_timer_id = null;
+        source_remove_if_alive(this._asyncTimeoutId);
+        this._asyncTimeoutId = null;
     }
 }

--- a/system-monitor-next@paradoxxx.zero.gmail.com/base.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/base.js
@@ -908,15 +908,24 @@ export const ElementBase = class SystemMonitor_ElementBase extends TipBox {
             sm_log("Invalid call to restart_update_timer", 'error');
             return;
         }
-        if (this.timeout) {
-            GLib.Source.remove(this.timeout);
-        }
+        source_remove_if_alive(this.timeout);
         this.timeout = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT_IDLE,
             interval,
             this.update.bind(this),
         );
         this._lastInterval = interval;
+    }
+    /**
+     * Re-arms the update timer if the GC destroyed its source. Called by the
+     * extension's watchdog; returns true if a repair was needed.
+     */
+    revive_update_timer() {
+        if (this._destroyed || source_is_alive(this.timeout))
+            return false;
+        this.timeout = null;
+        this.restart_update_timer();
+        return true;
     }
     tip_format(unit) {
         if (typeof (unit) === 'undefined') {

--- a/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor-next@paradoxxx.zero.gmail.com/extension.js
@@ -21,6 +21,7 @@
 import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 
 import GLib from "gi://GLib";
+import GnomeDesktop from "gi://GnomeDesktop";
 import Shell from "gi://Shell";
 import Gio from "gi://Gio";
 import St from "gi://St";
@@ -31,7 +32,7 @@ import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 
 import { sm_log } from './utils.js';
 import { migrateSettings } from './migration.js';
-import { color_from_string, smStyleManager, build_menu_info } from './base.js';
+import { color_from_string, smStyleManager, build_menu_info, source_remove_if_alive } from './base.js';
 import { smMountsMonitor, Bar, Pie } from './mounts.js';
 import { Battery } from './widgets/battery.js';
 import { Cpu } from './widgets/cpu.js';
@@ -333,7 +334,8 @@ export default class SystemMonitorExtension extends Extension {
                             return GLib.SOURCE_CONTINUE;
                         });
                 } else {
-                    GLib.Source.remove(this.menuTimeout);
+                    source_remove_if_alive(this.menuTimeout);
+                    this.menuTimeout = null;
                 }
             },
             this
@@ -355,13 +357,54 @@ export default class SystemMonitorExtension extends Extension {
         });
         tray.menu.addMenuItem(item);
         Main.panel.menuManager.addMenu(tray.menu);
+
+        this._startTimerWatchdog();
+    }
+
+    /**
+     * Watches for update timers destroyed by the GC and re-arms them.
+     *
+     * GJS blocks JS callbacks while the GC is sweeping, and a blocked
+     * SourceFunc is read as G_SOURCE_REMOVE, so every widget's timeout can be
+     * destroyed at once — permanently, and with nothing logged. An incremental
+     * sweep spans many main loop iterations, so this is not rare: a shell
+     * re-exec on a large heap reliably kills all of them a few seconds in.
+     *
+     * GnomeDesktop.WallClock drives its 'clock' property from C, so
+     * notify::clock keeps arriving. A signal handler blocked mid-sweep only
+     * misses that one emission and stays connected, unlike a SourceFunc, which
+     * is why this can repair timers that cannot repair themselves.
+     */
+    _startTimerWatchdog() {
+        // force_seconds so notify::clock arrives every second: widgets refresh
+        // on sub-second to few-second intervals, and a minute-granular
+        // watchdog would leave the panel visibly dead for far too long.
+        this._wallClock = new GnomeDesktop.WallClock({force_seconds: true});
+        this._wallClockId = this._wallClock.connect('notify::clock', () => {
+            if (!this.__sm)
+                return;
+            let revived = 0;
+            for (const elt of this.__sm.elts) {
+                if (elt.revive_update_timer?.())
+                    revived++;
+            }
+            if (revived)
+                sm_log(`re-armed ${revived} update timer(s) destroyed during GC`, 'warn');
+        });
+    }
+
+    _stopTimerWatchdog() {
+        if (this._wallClockId) {
+            this._wallClock.disconnect(this._wallClockId);
+            this._wallClockId = null;
+        }
+        this._wallClock = null;
     }
 
     disable() {
-        if (this.menuTimeout) {
-            GLib.Source.remove(this.menuTimeout);
-            this.menuTimeout = null;
-        }
+        this._stopTimerWatchdog();
+        source_remove_if_alive(this.menuTimeout);
+        this.menuTimeout = null;
         this._Schema.disconnectObject(this);
         // restore clock
         if (this.__sm.tray.clockMoved) {


### PR DESCRIPTION
Every widget's update timer can be destroyed at once, permanently, with nothing logged. GJS blocks JS callbacks while the GC is sweeping; a blocked `SourceFunc` returns no value, which GLib reads as `G_SOURCE_REMOVE`. `update()` already returns `SOURCE_CONTINUE` explicitly, so the source dies with no code path noticing and the panel never updates again until the extension is toggled.

Sweeping is incremental — the comment in gjs `context.cpp` notes `SweepPhase` can be interleaved with JS and native code — and `m_in_gc_sweep` stays set for the whole collection, not one slice, so the window spans seconds of main loop iterations rather than a single tick.

`base:` adds `source_is_alive()` / `source_remove_if_alive()`, and uses the guarded form in `ElementBase.destroy()` and the graph scale cooldown, which both removed unconditionally and could emit `Source ID N was not found when attempting to remove it`.

`extension:` re-arms dead timers from a `GnomeDesktop.WallClock`, whose `clock` property is driven from C so `notify::clock` keeps arriving. A signal handler blocked mid-sweep only misses that single emission and stays connected, unlike a `SourceFunc` — the same asymmetry that keeps the stock panel clock alive while extension timers die. One clock for the extension rather than one per widget.

This cannot cover the sweep window itself, since the sweep blocks JS by definition, including the watchdog. Timers resume when it ends.

### What I tested

- [x] Verified no regressions to existing functionality.
- [x] Tested on the following Gnome Shell versions: 46 (Ubuntu 24.04, X11)

`make clean build` and `npm run lint` pass at each commit in the series.

Reproduced on GNOME Shell 46 with a ~500 MB shell heap: on `Alt+F2` `r`, all ten widget timers armed, ticked for two seconds, then 21 blocked `SourceFunc`s a few seconds later and the panel froze permanently. With the patch, the same storm produces:

```
16:00:22.796  applet enable
16:00:23.577  GNOME Shell started
16:00:23-31   11 blocked SourceFuncs, 12 blocked WallClock notifies
16:00:32.003  [system-monitor-next] re-armed 10 update timer(s) destroyed during GC
```

One re-arm pass repairing all ten, and no `Source ID` criticals. The WallClock handler was itself blocked 12 times and still recovered. Panel has been updating normally since.

`vm-test.sh` did not run on this host: `virt-install` 4.1.0 on Ubuntu 24.04 rejects the passt `backend.type`/`portForward0.*` suboptions in `vm-create.sh`, and once those are supplied as raw XML instead, Ubuntu's `usr.bin.passt` AppArmor profile denies passt `file_mmap` of `/usr/bin/passt`, so libvirt-launched passt dies with SIGSEGV.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mgalgs/gnome-shell-system-monitor-next-applet/155)
<!-- Reviewable:end -->
